### PR TITLE
BookmarkRepository의 기본 CRUD 유닛 테스트

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -37,7 +37,8 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 
-	// mysql
+	// database
+	testImplementation 'com.h2database:h2'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 
 	// lombok

--- a/server/src/main/java/wap/starlist/bookmark/service/BookmarkService.java
+++ b/server/src/main/java/wap/starlist/bookmark/service/BookmarkService.java
@@ -28,7 +28,11 @@ public class BookmarkService {
     }
 
     @Transactional(readOnly = true)
-    public Bookmark getBookmark(long id) {
+    public Bookmark getBookmark(Long id) {
+        if (id == null) {
+            throw new IllegalArgumentException("[ERROR] id 값이 존재하지 않습니다.");
+        }
+
         // id로 북마크 조회
         return bookmarkRepository.findById(id)
                 .orElseThrow(() -> new IllegalArgumentException("[ERROR] 해당 북마크가 존재하지 않습니다."));

--- a/server/src/test/java/wap/starlist/bookmark/repository/BookmarkRepositoryTest.java
+++ b/server/src/test/java/wap/starlist/bookmark/repository/BookmarkRepositoryTest.java
@@ -1,0 +1,73 @@
+package wap.starlist.bookmark.repository;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.jpa.repository.support.JpaEntityInformation;
+import org.springframework.data.jpa.repository.support.JpaEntityInformationSupport;
+import wap.starlist.bookmark.domain.Bookmark;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+@DataJpaTest
+class BookmarkRepositoryTest {
+
+    @Autowired
+    private BookmarkRepository bookmarkRepository;
+    @PersistenceContext
+    private EntityManager entityManager;
+    private JpaEntityInformation<Bookmark, ?> entityInformation;
+
+    @BeforeEach
+    void setUp() {
+        entityInformation = JpaEntityInformationSupport
+                .getEntityInformation(Bookmark.class, entityManager);
+    }
+
+    @Test
+    void save() throws Exception {
+        //given
+        Bookmark earth = new Bookmark();
+
+        //when
+        Bookmark saved = bookmarkRepository.save(earth); // 반환된 값은 영속 상태임
+
+        //then
+        assertThat(saved).isEqualTo(earth);
+    }
+
+    @Test
+    void find() throws Exception {
+        //when
+        Bookmark saved = bookmarkRepository.save(new Bookmark());
+        Optional<Bookmark> found = bookmarkRepository.findById(saved.getId());
+
+        //then
+        assertThat(found).hasValue(saved);
+    }
+
+    @Test
+    void delete() throws Exception {
+        //given
+        Bookmark earth = bookmarkRepository.save(new Bookmark());
+        Long earthId = earth.getId();
+
+        //when
+        bookmarkRepository.deleteById(earthId);
+
+        //then
+        assertAll(
+                () -> assertFalse(entityManager.contains(earth)), // earth는 영속 상태가 아님
+                () -> assertEquals(earthId, entityInformation.getId(earth)), // earth는 상제상태라서 id는 존재
+                () -> assertDoesNotThrow(() -> bookmarkRepository.findById(earthId)), // 조회는 성공하지만 (NoSuchElement 없이 Optional 반환)
+                () -> assertThat(bookmarkRepository.findById(earthId)).isNotPresent() // 값은 가져올 수 없음
+        );
+
+    }
+}

--- a/server/src/test/java/wap/starlist/bookmark/service/BookmarkServiceTest.java
+++ b/server/src/test/java/wap/starlist/bookmark/service/BookmarkServiceTest.java
@@ -1,0 +1,92 @@
+package wap.starlist.bookmark.service;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientService;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
+import org.springframework.transaction.annotation.Transactional;
+import wap.starlist.bookmark.domain.Bookmark;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+
+@SpringBootTest
+@Transactional
+class BookmarkServiceTest {
+
+    @Autowired
+    private BookmarkService bookmarkService;
+
+    @Test
+    void create() throws Exception {
+        //given
+        String title = "EARTH1";
+        String url = "www.earth.org";
+
+        //when
+        Bookmark bookmark = bookmarkService.createBookmark(title, url);
+
+        //then
+        Bookmark foundBookmark = bookmarkService.getBookmark(bookmark.getId());
+
+        assertEquals(title, foundBookmark.getTitle());
+        assertEquals(url, foundBookmark.getUrl());
+    }
+
+    @Test
+    void get() throws Exception {
+        //given
+        String title = "EARTH2";
+        String url = "www.earth.org";
+
+        //when
+        Bookmark bookmark = bookmarkService.createBookmark(title, url);
+        Bookmark found = bookmarkService.getBookmark(bookmark.getId());
+        System.out.println("id = " + bookmarkService.getBookmark(3L).getTitle());
+        //then
+        assertEquals(found.getId(), bookmark.getId());
+    }
+
+    @Test
+    void throwErrorWhenNullId() throws Exception {
+        //given
+        Long nullId = null;
+
+        //then
+        assertThrows(IllegalArgumentException.class
+                , () -> bookmarkService.getBookmark(nullId));
+    }
+
+    @Test
+    void throwErrorWhenNoBookmark() throws Exception {
+        //given
+        String title = "EARTH3";
+        String url = "www.earth.org";
+
+        //when
+        Bookmark earth = bookmarkService.createBookmark(title, url);
+
+        //then
+        assertThrows(IllegalArgumentException.class,
+                () -> bookmarkService.getBookmark(earth.getId() + 1L));
+    }
+
+    @TestConfiguration
+    static class TestSecurityConfig {
+
+        @Bean
+        public ClientRegistrationRepository clientRegistrationRepository() {
+            return Mockito.mock(ClientRegistrationRepository.class);
+        }
+
+        @Bean
+        public OAuth2AuthorizedClientService oAuth2AuthorizedClientService() {
+            return Mockito.mock(OAuth2AuthorizedClientService.class);
+        }
+    }
+
+}

--- a/server/src/test/resources/application.yml
+++ b/server/src/test/resources/application.yml
@@ -1,0 +1,23 @@
+spring:
+  datasource:
+    url: jdbc:h2:mem:testdb
+    username: sa
+    password:
+    driver-class-name: org.h2.Driver
+
+  h2:
+    console:
+      enabled: true
+      path: /h2
+
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    properties:
+      hibernate:
+        default_batch_fetch_size: 1000
+        format_sql: true
+    defer-datasource-initialization: true
+    database-platform: org.hibernate.dialect.H2Dialect
+    show-sql: true
+    generate-ddl: true


### PR DESCRIPTION
## 🔍 관련 이슈 
<!-- 관련된 이슈 번호를 연결하세요 (예: #23) -->
#5


## ✅ 작업 내용 요약
<!-- 어떤 작업을 했는지 한두 문장으로 요약해주세요 -->
- save 시 입력 객체와 반환 객체가 동일한지 확인
- 저장된 객체를 `findById`로 조회 가능한지 확인
- `deleteByid`로 삭제 후 삭제 상태를 확인






## 💡 변경 사항 상세
<!-- 어떤 파일이 변경되었고, 주요 변경사항은 무엇인지 설명해주세요 -->
**🤷‍♀️ save test, find test**
두 개의 테스트를 실행할 때 하나의 객체로 실행하면 안됨.
`static final Bookmark EARTH = new Bookmark()`로 테스트 시 실패함.
영속 상태의 entity와 준영속 상태의 entity의 id가 다르기 때문임

더 자세한 내용은 [10분 테코톡](https://www.youtube.com/watch?v=kJexMyaeHDs&t=315s)을 참고하세요!!
<br/>

**🤷‍♂️ delete test**
삭제 상태란 id를 가지고 영속성 컨텍스트와 연결되어 있지만 DB에서 제거되지 않은 상태를 말함

즉, 삭제될거라고 예정된 상태임

- `contains`로 영속 상태인지 확인
- `deleteById`로 삭제시킨 earth 엔티티가 id가 여전히 존재하는지 확인
- id로 조회 가능한지 확인
- 값을 가져올 수 있는지 확인


테스트가 많이 남아있습니다.. 시험기간이므로 천천히 commit을 올리도롭 하겠습니다

<!--
## 🧪 테스트 결과
어떤 테스트를 했고, 결과가 어땠는지 적어주세요
- [ ] 로컬에서 테스트 완료
- [ ] 관련 테스트 코드 수정/추가
- [ ] CI 통과 확인

---


## 📸 스크린샷 (선택)
UI 작업일 경우, 변경된 화면 캡처를 첨부해주세요 
---

## 🔒 기타 참고 사항
리뷰어가 알아야 할 추가 정보가 있다면 적어주세요 (ex: 주의할 점, 트러블슈팅 등) 

---

## 🙏 리뷰어에게 바라는 점
어떤 부분을 중점적으로 봐주면 좋을지 적어주세요 (선택) 
- ex) 성능 개선이 잘 되었는지 봐주세요

-->
