### PR TITLE
feat: 로그인 요청/응답 기능 구현

### DIFF
--- a/extension/.gitignore
+++ b/extension/.gitignore
@@ -22,3 +22,6 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+# 추가
+.env

--- a/extension/public/manifest.json
+++ b/extension/public/manifest.json
@@ -12,6 +12,11 @@
   "background": {
     "service_worker": "./assets/js/service_worker.js"
   },
+  "externally_connectable": {
+    "matches": ["https://app.example.com/*"]
+  },
   "permissions": [
+    "tabs",
+    "storage"
   ]
 }

--- a/extension/src/popup/components/LoginButton.jsx
+++ b/extension/src/popup/components/LoginButton.jsx
@@ -1,14 +1,19 @@
 import React from 'react';
 
-function LoginButton() {
-    const handleLogin = () => {
-        window.open('https://example.com', '_parent'); // 새 창으로 열기
-    };
+// 미리 정의된 tailwind 스타일
+const STYLE_MAP = {
+    default: "w-[449px] h-[152px] rounded-[40px] bg-[#57418b] text-white",
+    loading: "w-[449px] h-[152px] rounded-[40px] bg-[#ddd9e7] text-black cursor-not-allowed"
+};
 
+function LoginButton({ onClick }) {
     return (
-        <div>
-            <button onClick={handleLogin}>로그인</button>
-        </div>
+        <button 
+            className={STYLE_MAP.default}
+            onClick={onClick}
+        >
+            로그인
+        </button>
     );
 }
 

--- a/extension/src/popup/hooks/useNavigation.js
+++ b/extension/src/popup/hooks/useNavigation.js
@@ -1,25 +1,25 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 const useNavigation = () => {
   const navigate = useNavigate();
 
   // 특정 페이지로 이동하는 함수를 정의합니다.
-  const goToLoginPage = () => {
+  const goToLoginPage = useCallback(() => {
     navigate('../pages/LoginPage');
-  };
+  }, [navigate]);
 
-  const goToSyncStartPage = () => {
+  const goToSyncStartPage = useCallback(() => {
     navigate('../pages/SyncStart')
-  }
+  }, [navigate]);
 
-  const goToSyncLoadingPage = () => {
+  const goToSyncLoadingPage = useCallback(() => {
     navigate('../pages/SyncLoading')
-  }
+  }, [navigate]);
 
-  const goToMainPage = () => {
+  const goToMainPage = useCallback(() => {
     navigate('../pages/MainPage');
-  };
+  }, [navigate]);
   
   return {
     goToLoginPage,

--- a/extension/src/popup/pages/LoginPage.jsx
+++ b/extension/src/popup/pages/LoginPage.jsx
@@ -1,0 +1,67 @@
+import React, { useEffect } from 'react';
+import useNavigation from '../hooks/useNavigation';
+
+import Logo from '../components/Logo';
+import Text from '../components/Text';
+import LoginButton from '../components/LoginButton';
+
+/* global chrome */
+
+/*
+chrome.runtime.sendMessage 와 sendResponse 는 JS 의 return 으로 흐름이 연결되는 것이 아니라,
+크롬 런타임(브라우저)에 내장된 IPC(프로세스 간 통신) 매커니즘을 통해 동작한다.
+
+팝업이나 React 컴포넌트와 서비스 워커는 별도 컨텍스트(스레드/프로세스)로 실행되기 때문에,
+이 둘을 이어 주는 다리가 바로 메시지 채널인 것이다.
+*/
+
+/* 
+    chrome.runtime.sendMessage(
+        extensionId?: string,      # 생략시, message 가 자체 확장프로그램/앱 으로 전송됨
+        message: any,              # 이 값은 JSON으로 변환 가능한 객체 이여야 함
+        options?: object,
+        callback?: function,       # callback 매개변수 : (response: any) => void
+    ) 
+*/
+
+/*
+<로그인 흐름도>
+1. LoginButton Click
+2. service worker 에서 로그인 웹페이지로 redirect
+3. 웹 서버에서 jwt 토큰, hasSynced 를 백엔드 서버로부터 받음
+4. 이를 웹 페이지에서 service worker 로 message 전송
+5. service worker 는 이 메시지를 수신하여 유효성 판단 후 storage 에 jwt 토큰과 hasSynced 를 저장
+6. LoginPage 에서 이를 감지하여 hasSynced 에 따라 Page 를 라우팅
+*/
+
+function LoginPage() {
+    const { goToMainPage, goToSyncStartPage } = useNavigation();
+
+    // 팝업이 열릴 때마다 token 유무 검사
+    useEffect(() => {
+        chrome.storage.local.get(['userToken', 'hasSynced'], ({ userToken, hasSynced }) => {
+            if (userToken) {
+                hasSynced ? goToMainPage() : goToSyncStartPage();
+            }
+        });
+    }, [goToMainPage, goToSyncStartPage]);
+
+    const handleLogin = () => {
+        chrome.runtime.sendMessage({ type: 'LOGIN_BUTTON_CLICKED' }, (response) => {
+          if (!response.success) 
+            console.log('Redirect 실패: ', response.error);
+          else
+            console.log('Redirect 성공');
+        });
+    };
+
+    return (
+        <div>
+            <Logo width='100px' height='100px'/>
+            <Text style='default' content='지금 로그인하고 내 북마크에 새로운 빛을 더해보세요'/>
+            <LoginButton onClick={handleLogin}/>
+        </div>
+    );
+}
+
+export default LoginPage;

--- a/extension/src/service_worker/service_worker.js
+++ b/extension/src/service_worker/service_worker.js
@@ -1,0 +1,40 @@
+const LOGIN_PAGE_URL = import.meta.env.VITE_LOGIN_PAGE_URL;
+const ALLOWED_URL     = import.meta.env.VITE_ALLOWED_URL;
+
+/* global chrome */
+
+// 1. 로그인 버튼 클릭시 로그인 웹페이지로 redirect
+chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+    if (message.type == 'LOGIN_BUTTON_CLICKED') {
+        // create() 가 비동기 API 라서 해당 함수 내부의 콜백 함수를 실행하기 위해서는
+        // 콜백 함수 실행 시점까지 service worker 가 살아있어야 함
+        chrome.tabs.create({ url:LOGIN_PAGE_URL }, () => {
+            if (chrome.runtime.lastError) {
+                // 탭 생성 실패 시
+                sendResponse({
+                  success: false,
+                  error: chrome.runtime.lastError.message
+                });
+            }
+            else
+                sendResponse({ success: true }); 
+        })
+        // 따라서, 명시적으로 service worker 가 살아있게 하기 위해 return true 를 사용
+        return true;
+    }
+});
+
+// 2. 웹페이지에서 로그인 성공에 대한 메시지 전송시 JWT, hasSynced 저장
+chrome.runtime.onMessageExternal.addListener((message, sender, sendResponse) => {
+    if (message.type == 'SET_JWT') {
+        if (!sender.url.startsWith(ALLOWED_URL)) {
+            sendResponse({ success:false });
+            return false;
+        }
+
+        chrome.storage.local.set({ userToken:message.token, hasSynced:message.hasSynced }, () => {
+            sendResponse({ success:true })
+        });
+        return true;
+    }
+});


### PR DESCRIPTION
## 🔍 관련 이슈 
Resolve : #29 


## ✅ 작업 내용 요약
- `service_worker.js` : `LoginPage.jsx` 에서 전송된 메시지를 입력받아 다음의 작업을 수행
  1. 웹의 로그인 페이지로 Redirect
  2. 웹페이지에서 로그인 성공시 토큰과 최초 동기화 여부 (`hasSynced`) 를 `chrome.storage.local` 에 저장 
- `LoginButton.jsx` : 로그인 버튼의 일관된 UI를 담당, 클릭 시 로직을 부모 컴포넌트에게 위임
- `LoginPage.jsx` :  해당 컴포넌트는 다음과 같은 작업을 수행
  1. 팝업이 열릴때마다 토큰 유무를 `chrome.storage.local` 에서 검사하여 결과에 따른 페이지 이동을 수행
  2. 로그인 버튼 클릭 이벤트 발생시 `service_worker.js` 에 메시지를 전달하여 통신을 수행

## 💡 변경 사항 상세
- `.gitignore` : `.env` 추가
- `manifest.json` 에서 권한 설정 부분을 추가
- `LoginButton.jsx`, `LoginPage.jsx`,  `service_worker.js` 에서 로그인 관련 로직을 완성
- `useNavigation.js` 에서 `useCallback` 으로  `navigate` 함수들을 묶어 `LoginPage.jsx` 의 `useEffect` 부분에서 정상적인 의존성 관리를 가능하게 하였음.