### PR TITLE
익스텐션에서 전송한 BookmarkTreeNode를 저장하는 기능

### DIFF
--- a/server/src/main/java/wap/starlist/bookmark/controller/BookmarkController.java
+++ b/server/src/main/java/wap/starlist/bookmark/controller/BookmarkController.java
@@ -3,9 +3,13 @@ package wap.starlist.bookmark.controller;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.User;
 import org.springframework.web.bind.annotation.*;
 import wap.starlist.bookmark.domain.Bookmark;
+import wap.starlist.bookmark.domain.Folder;
 import wap.starlist.bookmark.dto.request.BookmarkCreateRequest;
+import wap.starlist.bookmark.dto.request.BookmarkTreeNode;
 import wap.starlist.bookmark.dto.request.BookmarksDeleteRequest;
 import wap.starlist.bookmark.dto.response.BookmarkErrorResponse;
 import wap.starlist.bookmark.dto.response.BookmarkResponse;
@@ -68,5 +72,13 @@ public class BookmarkController {
 
         BookmarkResponse response = BookmarkResponse.from(bookmark);
         return ResponseEntity.ok().body(response);
+    }
+
+    @PostMapping("/sync")
+    public ResponseEntity<?> sync(@AuthenticationPrincipal User user,
+                                  @RequestBody List<BookmarkTreeNode> bookmarkTreeNodes) {
+
+        Folder savedFolder = bookmarkService.saveAll(bookmarkTreeNodes);
+        return ResponseEntity.ok().build();
     }
 }

--- a/server/src/main/java/wap/starlist/bookmark/domain/Bookmark.java
+++ b/server/src/main/java/wap/starlist/bookmark/domain/Bookmark.java
@@ -45,8 +45,11 @@ public class Bookmark {
 
     private Integer googleId;
 
-    private Folder folderId;
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "folder_id")
     private Folder folder;
+
+    public void updateFolder(Folder parentFolder) {
+        this.folder = parentFolder;
+    }
 }

--- a/server/src/main/java/wap/starlist/bookmark/domain/Bookmark.java
+++ b/server/src/main/java/wap/starlist/bookmark/domain/Bookmark.java
@@ -22,6 +22,7 @@ public class Bookmark {
 
     private String recommended;
 
+    @Column(length = 2048)
     private String url;
 
     private Long dateAdded;
@@ -32,16 +33,20 @@ public class Bookmark {
 
     private Integer position;
 
-    private Long parentId;
+    @Column(name = "parent_id")
+    private Integer parentId;
 
+//TODO: ROOT를 삭제하면 관련 필드 모두 삭제
     // ROOT 혹은 FOLDER로 저장됨
-    @Enumerated(EnumType.STRING)
-    private ParentType parentType;
+//    @Enumerated(EnumType.STRING)
+//    private ParentType parentType;
 
     private Boolean syncing;
 
     private Integer googleId;
 
-    @ManyToOne
     private Folder folderId;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "folder_id")
+    private Folder folder;
 }

--- a/server/src/main/java/wap/starlist/bookmark/domain/Folder.java
+++ b/server/src/main/java/wap/starlist/bookmark/domain/Folder.java
@@ -6,6 +6,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Entity
@@ -21,7 +22,21 @@ public class Folder {
 
     private String title;
 
-    private Long googleId;
+    @Column(nullable = false)
+    private Integer googleId;
+
+//    @ManyToOne
+//    private Root rootId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name ="parent_id")
+    private Folder parent;
+
+    @OneToMany(mappedBy = "google_id", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Folder> folders = new ArrayList<>();
+
+    @OneToMany(mappedBy = "folder")
+    private List<Bookmark> bookmarks = new ArrayList<>();
 
     @ManyToOne
     private Root rootId;

--- a/server/src/main/java/wap/starlist/bookmark/domain/Folder.java
+++ b/server/src/main/java/wap/starlist/bookmark/domain/Folder.java
@@ -38,9 +38,19 @@ public class Folder {
     @OneToMany(mappedBy = "folder")
     private List<Bookmark> bookmarks = new ArrayList<>();
 
-    @ManyToOne
-    private Root rootId;
 
-    @OneToMany(mappedBy = "folderId")
-    private List<Bookmark> bookmarks;
+    public void updateChildFolders(List<Folder> folders) {
+        this.folders = folders;
+        for (Folder child : folders) {
+            child.setParent(this);
+        }
+    }
+
+    public void updateChildBookmarks(List<Bookmark> bookmarks) {
+        this.bookmarks = bookmarks;
+    }
+
+    private void setParent(Folder parent) {
+        this.parent = parent;
+    }
 }

--- a/server/src/main/java/wap/starlist/bookmark/domain/Root.java
+++ b/server/src/main/java/wap/starlist/bookmark/domain/Root.java
@@ -1,20 +1,26 @@
-package wap.starlist.bookmark.domain;
-
-import jakarta.persistence.*;
-import wap.starlist.member.domain.Member;
-
-import java.util.List;
-
-@Entity
-public class Root {
-
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
-
-    @OneToOne
-    private Member memberId;
-
-    @OneToMany(mappedBy = "rootId")
-    private List<Folder> folders;
-}
+//package wap.starlist.bookmark.domain;
+//
+//import jakarta.persistence.*;
+//import lombok.AllArgsConstructor;
+//import lombok.Builder;
+//import lombok.NoArgsConstructor;
+//import wap.starlist.member.domain.Member;
+//
+//import java.util.List;
+//
+//@Entity
+//@Builder
+//@NoArgsConstructor
+//@AllArgsConstructor
+//public class Root {
+//
+//    @Id
+//    @GeneratedValue(strategy = GenerationType.IDENTITY)
+//    private Long id;
+//
+//    @OneToOne
+//    private Member memberId;
+//
+//    @OneToMany(mappedBy = "rootId")
+//    private List<Folder> folders;
+//}

--- a/server/src/main/java/wap/starlist/bookmark/dto/request/BookmarkTreeNode.java
+++ b/server/src/main/java/wap/starlist/bookmark/dto/request/BookmarkTreeNode.java
@@ -1,0 +1,53 @@
+package wap.starlist.bookmark.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import wap.starlist.bookmark.domain.Bookmark;
+import wap.starlist.bookmark.domain.Folder;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class BookmarkTreeNode {
+
+    private String id; // google id
+    private Boolean syncing;
+    private String title;
+    private Long dateAdded;
+    private Long dateGroupModified;
+    private Integer index;
+    private Integer parentId;
+    private String url;
+    private String folderType;
+    private List<BookmarkTreeNode> children;
+
+//    public Root toRoot(Member member) {
+//        return Root.builder()
+//                .memberId(member)
+//                .folders(children)
+//                .build();
+//    }
+
+    public Folder toFolder(List<Folder> childFolders, List<Bookmark> childBookmarks) {
+        return Folder.builder()
+                .googleId(Integer.parseInt(id))
+                .title(title)
+                .bookmarks(childBookmarks)
+                .folders(childFolders)
+                .build();
+    }
+
+    public Bookmark toBookmark() {
+        return Bookmark.builder()
+                .googleId(Integer.parseInt(id))
+                .title(title)
+                .url(url)
+                .dateAdded(dateAdded)
+                .dateGroupModified(dateGroupModified)
+                .parentId(parentId)
+                .build();
+    }
+}

--- a/server/src/main/java/wap/starlist/bookmark/repository/RootRepository.java
+++ b/server/src/main/java/wap/starlist/bookmark/repository/RootRepository.java
@@ -1,9 +1,9 @@
-package wap.starlist.bookmark.repository;
-
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
-import wap.starlist.bookmark.domain.Root;
-
-@Repository
-public interface RootRepository extends JpaRepository<Root, Long> {
-}
+//package wap.starlist.bookmark.repository;
+//
+//import org.springframework.data.jpa.repository.JpaRepository;
+//import org.springframework.stereotype.Repository;
+//import wap.starlist.bookmark.domain.Root;
+//
+//@Repository
+//public interface RootRepository extends JpaRepository<Root, Long> {
+//}

--- a/server/src/main/java/wap/starlist/bookmark/service/BookmarkService.java
+++ b/server/src/main/java/wap/starlist/bookmark/service/BookmarkService.java
@@ -1,12 +1,16 @@
 package wap.starlist.bookmark.service;
 
-import java.util.List;
+import java.util.*;
+
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.CollectionUtils;
 import wap.starlist.bookmark.domain.Bookmark;
+import wap.starlist.bookmark.domain.Folder;
+import wap.starlist.bookmark.dto.request.BookmarkTreeNode;
 import wap.starlist.bookmark.repository.BookmarkRepository;
+import wap.starlist.bookmark.repository.FolderRepository;
 
 @Service
 @RequiredArgsConstructor
@@ -15,6 +19,8 @@ public class BookmarkService {
     private static final long MILLIS_PER_SECOND = 1000L;
 
     private final BookmarkRepository bookmarkRepository;
+    private final FolderRepository folderRepository;
+    //rivate final RootRepository rootRepository;
 
     @Transactional // 트랜잭션을 보장하기 위해
     public Bookmark createBookmark(String title, String url) {
@@ -50,6 +56,63 @@ public class BookmarkService {
         bookmarkRepository.deleteAll(toDelete); // 북마크 일괄 삭제
 
         return toDelete.size(); // 삭제된 북마크 개수 반환
+    }
+
+
+    //TODO: 1차 변환 후 2차 저장이 가능한지
+    // 상위 객체를 저장하기 위해 하위 객체를 준비해야하므로 Bottom-up으로 DFS를 통해 구현
+    @Transactional
+    public Folder saveAll(List<BookmarkTreeNode> bookmarkTreeNodes) {
+        if (bookmarkTreeNodes.size() != 1) {
+            throw new IllegalArgumentException("[ERROR] 잘못된 북마크 트리 구조입니다. 관리자에게 문의해주세요.");
+        }
+
+        BookmarkTreeNode rootNode = bookmarkTreeNodes.get(0);
+        Folder root = collectNode(rootNode);
+
+        if (root == null) {
+            throw new IllegalArgumentException("[ERROR] 북마크가 최상위 노드일 순 없습니다.");
+        }
+
+        return root;
+    }
+
+    // DFS로 트리를 탐색
+    private Folder collectNode(BookmarkTreeNode node) {
+        if (isBookmark(node)) { // Bookmark
+            Bookmark leafBookmark = node.toBookmark();
+            bookmarkRepository.save(leafBookmark);
+            return null;
+        }
+
+        List<Folder> childFolders = new ArrayList<>();
+        List<Bookmark> childBookmarks = new ArrayList<>();
+
+        Folder currentFolder = node.toFolder(childFolders, childBookmarks); // 자식 없이 먼저 생성
+        folderRepository.save(currentFolder); // ID 생성을 위해 먼저 저장
+
+        // 현자 노드의 자식들을 탐색하며 db에 저장 or 다시 탐색한다
+        for (BookmarkTreeNode child : node.getChildren()) {
+            if (isBookmark(child)) { // Bookmark
+                Bookmark childBookmark = child.toBookmark();
+                childBookmark.updateFolder(currentFolder);
+                bookmarkRepository.save(childBookmark);
+                childBookmarks.add(childBookmark);
+            } else { // Folder
+                Folder childFolder = collectNode(child);
+                childFolders.add(childFolder);
+            }
+        }
+
+        // 연관관계를 수동으로 설정
+        currentFolder.updateChildFolders(childFolders);
+        currentFolder.updateChildBookmarks(childBookmarks);
+        // folderRepository.save(currentFolder);
+        return currentFolder;
+    }
+
+    private boolean isBookmark(BookmarkTreeNode node) {
+        return node.getChildren() == null;
     }
 
     // 현재 시간을 millis를 제외한 long으로 반환

--- a/server/src/main/java/wap/starlist/bookmark/service/BookmarkService.java
+++ b/server/src/main/java/wap/starlist/bookmark/service/BookmarkService.java
@@ -59,8 +59,8 @@ public class BookmarkService {
     }
 
 
-    //TODO: 1차 변환 후 2차 저장이 가능한지
     // 상위 객체를 저장하기 위해 하위 객체를 준비해야하므로 Bottom-up으로 DFS를 통해 구현
+    //TODO: 의미가 중복된 컬럼 제거해야함
     @Transactional
     public Folder saveAll(List<BookmarkTreeNode> bookmarkTreeNodes) {
         if (bookmarkTreeNodes.size() != 1) {
@@ -91,7 +91,7 @@ public class BookmarkService {
         Folder currentFolder = node.toFolder(childFolders, childBookmarks); // 자식 없이 먼저 생성
         folderRepository.save(currentFolder); // ID 생성을 위해 먼저 저장
 
-        // 현자 노드의 자식들을 탐색하며 db에 저장 or 다시 탐색한다
+        // 현재 노드의 자식들을 탐색하며 db에 저장 or 다시 탐색한다
         for (BookmarkTreeNode child : node.getChildren()) {
             if (isBookmark(child)) { // Bookmark
                 Bookmark childBookmark = child.toBookmark();

--- a/server/src/main/java/wap/starlist/bookmark/service/FolderService.java
+++ b/server/src/main/java/wap/starlist/bookmark/service/FolderService.java
@@ -20,9 +20,10 @@ public class FolderService {
             throw new IllegalArgumentException("[ERROR] 폴더명이 존재하지 않습니다.");
         }
 
+        //TODO: userId와 googleId는 매치되지 않음
         Folder folder = Folder.builder()
                 .title(title)
-                .googleId(userId)
+                //.googleId(userId)
                 .build();
 
         return folderRepository.save(folder);

--- a/server/src/main/java/wap/starlist/config/SecurityConfig.java
+++ b/server/src/main/java/wap/starlist/config/SecurityConfig.java
@@ -64,7 +64,8 @@ public class SecurityConfig {
 
         config.setAllowedOrigins(List.of(
                 "http://localhost:5174",
-                "https://sstarlist.netlify.app"
+                "https://sstarlist.netlify.app",
+                "chrome-extension://jdckgeplahiaefapkpnjjnffdjifmkok"
         ));
         config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));
         config.setAllowedHeaders(List.of("*"));

--- a/server/src/main/java/wap/starlist/config/auth/JwtTokenProvider.java
+++ b/server/src/main/java/wap/starlist/config/auth/JwtTokenProvider.java
@@ -33,11 +33,6 @@ public class JwtTokenProvider {
     private String key;
     private SecretKey secretKey;
 
-    @PostConstruct
-    private void setSecretKey() {
-        secretKey = Keys.hmacShaKeyFor(key.getBytes());
-    }
-
     public String generateAccessToken(Authentication authentication) {
         return generateToken(authentication, ACCESS_TOKEN_EXPIRE_TIME);
     }
@@ -71,6 +66,11 @@ public class JwtTokenProvider {
             System.out.println("[JWT] 토큰 검증 실패: " + e.getMessage());
         }
         return false;
+    }
+
+    @PostConstruct
+    private void setSecretKey() {
+        secretKey = Keys.hmacShaKeyFor(key.getBytes());
     }
 
     private String generateToken(Authentication authentication, long expireTime) {

--- a/server/src/main/java/wap/starlist/config/auth/handler/OAuth2SuccessHandler.java
+++ b/server/src/main/java/wap/starlist/config/auth/handler/OAuth2SuccessHandler.java
@@ -32,6 +32,8 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
                 .queryParam("token", accessToken)
                 .build().toUriString();
 
+        System.out.println("accessToken = " + accessToken);
+
         response.sendRedirect(redirectUrl);
     }
 }

--- a/server/src/main/java/wap/starlist/config/auth/handler/OAuth2SuccessHandler.java
+++ b/server/src/main/java/wap/starlist/config/auth/handler/OAuth2SuccessHandler.java
@@ -26,6 +26,7 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
         // 토큰 생성
         String accessToken = jwtTokenProvider.generateAccessToken(authentication);
 
+        //TODO: 쿼리로 전달하지 않고 쿠키를 사용하도록
         // accessToken을 쿼리 파라미터로 전달
         String redirectUrl = UriComponentsBuilder.fromUriString(REDIRECT_URI)
                 .queryParam("token", accessToken)


### PR DESCRIPTION
## 🔍 관련 이슈 
<!-- 관련된 이슈 번호를 연결하세요 (예: #23) -->
#58 


## ✅ 작업 내용 요약
<!-- 어떤 작업을 했는지 한두 문장으로 요약해주세요 -->
- 익스텐션에서 `chrome.bookmarks.getTree()`를 통해 전송한 [BookmarkTreeNode](https://developer.chrome.com/docs/extensions/reference/api/bookmarks?hl=ko#type-BookmarkTreeNode)를 저장
- BookmarkTreeNode는 트리구조로 저장되어 있어 DFS로 노드를 순회
- `/bookmarks/sync`로 POST 요청을 처리하는 기능 추가

## 💡 변경 사항 상세
<!-- 어떤 파일이 변경되었고, 주요 변경사항은 무엇인지 설명해주세요 -->
- 현재 편의를 위해 Root를 Folder로 생각하고 구현하였습니다. 연관관계 설정이 복잡하고, Root의 자식으로 Bookmark가 올 수 있다고 생각했으나 확인해보니 Root의 자식 Folder부터 추가할 수 있었습니다. 따라서 추후 Root를 추가하도록 하겠습니다.

### 🐦 BookmarkService#collectNode
- 재귀함수로 구현한 DFS로 트리를 순회합니다.
- 연관관계 매핑을 위해 엔티티를 생성한 후 `Folder#update...` 메서드로 값을 주입하여 연관관계를 매핑하고 있습니다.
    -> 일종의 `Setter`이긴한데 안티패턴인지 확인한 후 수정하려합니다.
- dfs에 익숙치 않다면 헷갈릴 수 있는 함수라.. 가독성이 매우 떨어진다고 생각합니다. 큐를 사용하거나 다른 방법을 모색  후 더 좋은 방향으로 리팩토링하려 합니다. 혹시 좋은 아이디어 있다면 코멘트 달아주세요!!
- 반드시 @Transactional을 사용하는 메서드에서 호출되어야 합니다.



## 🔒 기타 참고 사항
수정해야하는 코드가 많은데 다음 PR에서 수정하도록 하겠습니다.
`Root`를 복구하고 `collectNode`를 그에 맞게 변경 후 PR 올리겠습니다. 





<!--
## 🧪 테스트 결과
어떤 테스트를 했고, 결과가 어땠는지 적어주세요
- [ ] 로컬에서 테스트 완료
- [ ] 관련 테스트 코드 수정/추가
- [ ] CI 통과 확인

---


## 📸 스크린샷 (선택)
UI 작업일 경우, 변경된 화면 캡처를 첨부해주세요 
---



---

## 🙏 리뷰어에게 바라는 점
어떤 부분을 중점적으로 봐주면 좋을지 적어주세요 (선택) 
- ex) 성능 개선이 잘 되었는지 봐주세요

-->
