### PR TITLE
테스트 환경에서 oauth 관련 빈 생성이 이뤄지기 위해 환경변수 파일 추가

### DIFF
--- a/server/.gitignore
+++ b/server/.gitignore
@@ -38,7 +38,6 @@ out/
 .vscode/
 
 ### Secret File
-src/main/resources/application-db.properties
-src/main/resources/application-oauth.properties
 src/main/resources/application-db.yml
 src/main/resources/application-oauth.yml
+src/test/resources/application-test.yml

--- a/server/src/main/java/wap/starlist/bookmark/domain/Folder.java
+++ b/server/src/main/java/wap/starlist/bookmark/domain/Folder.java
@@ -32,7 +32,7 @@ public class Folder {
     @JoinColumn(name ="parent_id")
     private Folder parent;
 
-    @OneToMany(mappedBy = "google_id", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToMany(mappedBy = "parent", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Folder> folders = new ArrayList<>();
 
     @OneToMany(mappedBy = "folder")

--- a/server/src/main/java/wap/starlist/bookmark/dto/request/BookmarkTreeNode.java
+++ b/server/src/main/java/wap/starlist/bookmark/dto/request/BookmarkTreeNode.java
@@ -42,7 +42,7 @@ public class BookmarkTreeNode {
 
     public Bookmark toBookmark() {
         return Bookmark.builder()
-                .googleId(Integer.parseInt(id))
+                .googleId(Long.parseLong(id))
                 .title(title)
                 .url(url)
                 .dateAdded(dateAdded)

--- a/server/src/main/java/wap/starlist/bookmark/service/BookmarkService.java
+++ b/server/src/main/java/wap/starlist/bookmark/service/BookmarkService.java
@@ -1,5 +1,6 @@
 package wap.starlist.bookmark.service;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 

--- a/server/src/test/java/wap/starlist/bookmark/service/BookmarkServiceTest.java
+++ b/server/src/test/java/wap/starlist/bookmark/service/BookmarkServiceTest.java
@@ -1,13 +1,8 @@
 package wap.starlist.bookmark.service;
 
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.context.TestConfiguration;
-import org.springframework.context.annotation.Bean;
-import org.springframework.security.oauth2.client.OAuth2AuthorizedClientService;
-import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
 import org.springframework.transaction.annotation.Transactional;
 import wap.starlist.bookmark.domain.Bookmark;
 
@@ -74,19 +69,4 @@ class BookmarkServiceTest {
         assertThrows(IllegalArgumentException.class,
                 () -> bookmarkService.getBookmark(earth.getId() + 1L));
     }
-
-    @TestConfiguration
-    static class TestSecurityConfig {
-
-        @Bean
-        public ClientRegistrationRepository clientRegistrationRepository() {
-            return Mockito.mock(ClientRegistrationRepository.class);
-        }
-
-        @Bean
-        public OAuth2AuthorizedClientService oAuth2AuthorizedClientService() {
-            return Mockito.mock(OAuth2AuthorizedClientService.class);
-        }
-    }
-
 }

--- a/server/src/test/resources/application.yml
+++ b/server/src/test/resources/application.yml
@@ -1,6 +1,6 @@
 spring:
   datasource:
-    url: jdbc:h2:mem:testdb
+    url: jdbc:h2:mem:test_db
     username: sa
     password:
     driver-class-name: org.h2.Driver
@@ -21,3 +21,6 @@ spring:
     database-platform: org.hibernate.dialect.H2Dialect
     show-sql: true
     generate-ddl: true
+
+  profiles:
+    include: test


### PR DESCRIPTION
## ✅ 작업 내용 요약
<!-- 어떤 작업을 했는지 한두 문장으로 요약해주세요 -->
이전 테스트 시 oauth 관련 빈이 생성되지 않고, 로드되지 않아 문제가 발생하였습니다.
이에 `static class`로 `@TestConfiguration`을 `Mokito`를 사용해서 해주었는데, 다시 또 문제가 되어 수정하였습니다.

`@TestConfiguration`+`Mokito`도 좋은 방법이지만 컨텍스트 전체를 로드하는 테스트에서 매번 설정해주기 귀찮고 어렵습니다.

따라서 새로운 방법을 찾았습니다. `test/resoureces/application.yml`을 생성하는 것입니다. 아래를 설정해주는게 가장 편하다고 생각합니다. 이렇게 설정하면 로그인 관련 테스트도 진행할 수 있습니다!

```yml
spring:
  security:
    oauth2:
      client:
        # 외부 서비스에서 우리 서비스를 특정하기 위해 등록하는 정보
        registration:
          google:
            client-id: {YOUR_CLIENT_ID}
            client-secret: {YOUR_CLIENT_SECRET}
            redirect-uri: {YOUR_REDIRECT_URI}
            scope:
              - profile
              - email

        # 서비스별(구글, 깃허브, 페이스북)로 정해진 값이 존재
        # 네이버나 카카오는 authorization-uri와 token-uri 등을 등록해줘야 함.
        provider:
          google:
            user-name-attribute: sub

security:
  jwt:
    token:
      # 실제로 사용하지 않는 임시 키
      secret-key: {YOUR-SECRET-KEY}
      expire-time: 1800000

```

<img width="259" alt="image" src="https://github.com/user-attachments/assets/4601201d-44bc-4efb-a0ff-2f55c5de4a36" />

이렇게 두 설정파일을 작성하여 숨기고 싶은 항목들을 숨겨주는게 좋습니다.

<!--
## 🧪 테스트 결과
어떤 테스트를 했고, 결과가 어땠는지 적어주세요
- [ ] 로컬에서 테스트 완료
- [ ] 관련 테스트 코드 수정/추가
- [ ] CI 통과 확인

---


## 📸 스크린샷 (선택)
UI 작업일 경우, 변경된 화면 캡처를 첨부해주세요 
---

## 🔒 기타 참고 사항
리뷰어가 알아야 할 추가 정보가 있다면 적어주세요 (ex: 주의할 점, 트러블슈팅 등) 

---

## 🙏 리뷰어에게 바라는 점
어떤 부분을 중점적으로 봐주면 좋을지 적어주세요 (선택) 
- ex) 성능 개선이 잘 되었는지 봐주세요

-->
