### PR TITLE
feat: 전체 북마크 전송, 브라우저 북마크 이벤트 처리(추가,삭제,변경,이동) 기능 구현

### DIFF
--- a/extension/public/manifest.json
+++ b/extension/public/manifest.json
@@ -20,6 +20,15 @@
   "background": {
     "service_worker": "./assets/js/service_worker.js"
   },
+  "content_scripts": [{
+    "matches": ["https://sstarlist.netlify.app/main"],
+    "js": ["./assets/js/content_script.js"],
+    "run_at": "document_idle"
+  }],
+  "host_permissions": [
+    "https://sstarlist.netlify.app/*",
+    "https://starlist.store/*"
+  ],
   "externally_connectable": {
     "matches": ["https://sstarlist.netlify.app/*"]
   },

--- a/extension/src/content_script/content_script.js
+++ b/extension/src/content_script/content_script.js
@@ -1,0 +1,9 @@
+/* global chrome */
+
+// 메인 페이지가 로드되면 서비스 워커에 메시지를 전송
+window.addEventListener("load", () => {
+    chrome.runtime.sendMessage({
+        type: "MAIN_PAGE_VISTED",
+        url: window.location.href
+    });
+});

--- a/extension/src/popup/App.jsx
+++ b/extension/src/popup/App.jsx
@@ -3,18 +3,14 @@ import { HashRouter, Routes, Route } from 'react-router-dom';
 import './App.css'
 
 import LoginPage from './pages/LoginPage';
-import SyncStartPage from './pages/SyncStartPage';
-import SyncStatusPage from './pages/SyncStatusPage';
-import MainPage from './pages/MainPage';
+import SaveSuccessPage from './pages/SaveSuccessPage';
 
 function App() {
   return (
     <HashRouter>
       <Routes>
         <Route index element={<LoginPage/>}/>
-        <Route path='pages/MainPage' element={<MainPage/>}/>
-        <Route path='pages/SyncStartPage' element={<SyncStartPage/>}/>
-        <Route path='pages/SyncStatusPage' element={<SyncStatusPage/>}/>
+        <Route path='pages/SaveSuccessPage' element={<SaveSuccessPage/>}/>
       </Routes>
     </HashRouter>
   );

--- a/extension/src/popup/pages/LoginPage.jsx
+++ b/extension/src/popup/pages/LoginPage.jsx
@@ -1,69 +1,8 @@
-import React, { useEffect } from 'react';
-import useNavigation from '../hooks/useNavigation';
-
-import Logo from '../components/Logo';
-import Text from '../components/Text';
-import LoginButton from '../components/LoginButton';
-
-/* global chrome */
-
-/*
-chrome.runtime.sendMessage 와 sendResponse 는 JS 의 return 으로 흐름이 연결되는 것이 아니라,
-크롬 런타임(브라우저)에 내장된 IPC(프로세스 간 통신) 매커니즘을 통해 동작한다.
-
-팝업이나 React 컴포넌트와 서비스 워커는 별도 컨텍스트(스레드/프로세스)로 실행되기 때문에,
-이 둘을 이어 주는 다리가 바로 메시지 채널인 것이다.
-*/
-
-/* 
-    chrome.runtime.sendMessage(
-        extensionId?: string,      # 생략시, message 가 자체 확장프로그램/앱 으로 전송됨
-        message: any,              # 이 값은 JSON으로 변환 가능한 객체 이여야 함
-        options?: object,
-        callback?: function,       # callback 매개변수 : (response: any) => void
-    ) 
-*/
-
-/*
-<로그인 흐름도>
-1. LoginButton Click
-2. service worker 에서 로그인 웹페이지로 redirect
-3. 웹 서버에서 jwt 토큰, hasSynced 를 백엔드 서버로부터 받음
-4. 이를 웹 페이지에서 service worker 로 message 전송
-5. service worker 는 이 메시지를 수신하여 유효성 판단 후 storage 에 jwt 토큰과 hasSynced 를 저장
-6. LoginPage 에서 이를 감지하여 hasSynced 에 따라 Page 를 라우팅
-*/
+import React from 'react';
 
 function LoginPage() {
-    const { goToMainPage, goToSyncStartPage } = useNavigation();
-
-    // 팝업이 열릴 때마다 token 유무 검사
-    useEffect(() => {
-        chrome.storage.local.get(['userToken', 'hasSynced'], ({ userToken, hasSynced }) => {
-            if (userToken) {
-                hasSynced ? goToMainPage() : goToSyncStartPage();
-            }
-        });
-    }, [goToMainPage, goToSyncStartPage]);
-
-    const handleLogin = () => {
-        chrome.runtime.sendMessage({ type: 'LOGIN_BUTTON_CLICKED' }, (response) => {
-          if (!response.success) 
-            console.log('Redirect 실패: ', response.error);
-          else
-            console.log('Redirect 성공');
-        });
-    };
-
     return (
-        <div className='w-full h-full flex flex-col justify-center'>
-            <div className='p-5 flex flex-col justify-center items-center'>
-                <Logo className='pb-3' width='250px' height='250px'/>
-                <Text style='default' content='지금 로그인하고'/> 
-                <Text style='default' content='내 북마크에 새로운 빛을 더해보세요'/>
-                <LoginButton onClick={handleLogin}/>
-            </div>
-        </div>
+        <h1>test</h1>
     );
 }
 

--- a/extension/src/popup/pages/SaveSuccessPage.jsx
+++ b/extension/src/popup/pages/SaveSuccessPage.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+function SaveSuccessPage() {
+    return (
+        <h1>Success</h1>
+    );
+}
+
+export default SaveSuccessPage;

--- a/extension/src/service_worker/service_worker.js
+++ b/extension/src/service_worker/service_worker.js
@@ -1,111 +1,185 @@
-const LOGIN_PAGE_URL = import.meta.env.VITE_LOGIN_PAGE_URL;
-const ALLOWED_URL     = import.meta.env.ALLOWED_URL;
+const START_PAGE_URL = import.meta.env.VITE_START_PAGE_URL;
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL;
 
 /* global chrome */
 
-// 로그인 버튼 클릭시 로그인 웹페이지로 redirect
-chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
-    if (message.type == 'LOGIN_BUTTON_CLICKED') {
-        // create() 가 비동기 API 라서 해당 함수 내부의 콜백 함수를 실행하기 위해서는
-        // 콜백 함수 실행 시점까지 service worker 가 살아있어야 함
-        chrome.tabs.create({ url:LOGIN_PAGE_URL }, () => {
-            if (chrome.runtime.lastError) {
-                // 탭 생성 실패 시
-                sendResponse({
-                  success: false,
-                  error: chrome.runtime.lastError.message
-                });
-            }
-            else
-                sendResponse({ success: true }); 
-        })
-        // 따라서, 명시적으로 service worker 가 살아있게 하기 위해 return true 를 사용
-        return true;
+
+
+// ---------- 함수 정의 영역 ---------- // 
+
+
+
+// 웹의 시작 페이지를 새 탭으로 생성하는 함수
+function redirectStartPage() {
+    chrome.tabs.create({ url: START_PAGE_URL });
+}
+
+// 메시지에 포함된 토큰과 동기화 여부를 storage.local 에 저장하는 함수
+async function storeAccessToken(message) {
+    await chrome.storage.local.set({
+        userToken: message.token,
+        hasSynced: message.hasSynced
+    });
+}
+
+// 전체 북마크를 전송한 적이 있는지 판별하는 함수
+async function hasSentAllBookmarks() {
+    const { hasSynced } = await chrome.storage.local.get("hasSynced");
+    return hasSynced === true;
+}
+
+// 사용자의 토큰을 가져오는 함수
+async function getUserToken() {
+    try {
+        const result = await chrome.storage.local.get({ userToken: null });
+        const userToken = result.userToken;
+
+        if (!userToken)
+            throw new Error("토큰이 없습니다");
+        return userToken;
     }
-
-    else if (message.type === 'SYNC_START_BUTTON_CLICKED') {
-        // 응답 상태를 "LOADING" 으로 설정
-        chrome.storage.local.set({ syncStatus:'LOADING', syncError:null });
-
-        // chrome.bookmarks.getTree 를 활용하여 북마크 트리 전체 읽기
-        chrome.bookmarks.getTree((bookmarkTree) => {
-            const bookmarks = [];
-            traverseTree(bookmarkTree, bookmarks);
-
-            // 이후 백엔드 API 로 전체 북마크 리스트를 전송
-            // 함수 선언문을 괄호로 붙여 즉시 실행 함수로 변환
-            (async () => {
-                try 
-                {
-                    const response = await fetch(
-                        'https://api.example.com/bookmarks/sync',
-                        {
-                        method: 'POST',
-                        body: JSON.stringify({ data:bookmarks }),
-                        }
-                    );
-
-                    const result = await response.json();
-
-                    if (result.code != 'SUCCESS') {
-                        throw new Error(result.message);
-                    }
-                    // 성공 처리
-                    chrome.storage.local.set({ syncStatus:'SUCCESS' });
-                } 
-                catch (err) 
-                {
-                    // 실패 처리
-                    chrome.storage.local.set({
-                        syncStatus:'FAIL',
-                        syncError:err.message,
-                    });
-                }
-            }) ();
-        });
-        // 비동기 작업 처리를 위해 service worker 가 살아있게 하기 위해 return true 를 사용
-        return true;
-    }
-});
-
-
-// 웹페이지에서 로그인 성공에 대한 메시지 전송시 JWT, hasSynced 저장
-chrome.runtime.onMessageExternal.addListener((message, sender, sendResponse) => {
-    if (message.type == 'SET_JWT') {
-        // if (!sender.url.startsWith(ALLOWED_URL)) {
-        //     sendResponse({ success:false });
-        //     return false;
-        // }
-
-        chrome.storage.local.set({ userToken:message.token, hasSynced:message.hasSynced }, () => {
-            sendResponse({ success:true })
-        });
-        return true;
-    }
-});
-
-// 재귀 순회 함수 정의
-function traverseTree(tree, list) {
-    for (const node of tree) {
-        // primary key 에 해당하는 (id, title) 이 있는 노드만 전체 북마크 리스트에 저장
-        if (node.id && node.title) {
-            // 전체 북마크 리스트에 추가
-            list.push({
-                id:                 parseInt(node.id),                   // int -> Long
-                title:              node.title,                          // String
-                url:                node.url,                            // String
-                dateAdded:          node.dateAdded || null,              // Int
-                dateGroupModified:  node.dateGroupModified || null,      // Int
-                dateLastUsed:       node.dateLastUsed || null,           // Int
-                index:              node.index,                          // Int
-                parentId:           node.parentId,                       // String
-                parentType:         null,                                // 존재하지 않는 속성
-                syncing:            node.syncing,                        // Boolean
-                keywords:           []                                   // List<String>
-            });
-        }
-        if (node.children) {
-            traverseTree(node.children);
-        }
+    catch(error) {
+        console.error("토큰 조회 실패:", error);
+        throw error;
     }
 }
+
+// 전체 북마크 트리를 가져오는 함수
+// 필요한 북마크 트리는 "기타 북마크" 폴더를 루트로 가지는 트리임
+// 전체 북마크 트리에서 루트의 자식 노드 중 1번째 노드가 "기타 북마크" 에 해당
+// 이 폴더에 유저가 추가한 전체 북마크가 저장되어있음
+async function fetchBookmarkTree() {
+    try {
+        const bookmarkTree = await chrome.bookmarks.getTree();
+        // 가져온 북마크 트리가 undefined, null, empty 라면 에러 처리
+        if (!bookmarkTree?.length)
+            throw new Error("기타 북마크 폴더를 찾을 수 없습니다.");
+        return bookmarkTree;
+    }
+    catch(error) {
+        console.error("북마크 조회 실패:", error);
+        throw error;
+    }
+}
+
+// 전체 북마크 트리를 백엔드로 전송하는 함수
+async function sendAllBookmarks() {
+    try {
+        // 비동기적으로 토큰과 북마크 트리를 가져옴
+        const tokenPromise = getUserToken();
+        const bookmarkPromise = fetchBookmarkTree();
+
+        // 위의 비동기 작업이 모두 완료될때까지는 기다림
+        const [userToken, bookmarkTree] = await Promise.all([tokenPromise, bookmarkPromise]);
+
+        // 토큰과 북마크를 백엔드 API 로 전송
+        const response = await fetch(`${API_BASE_URL}/bookmarks/sync`, {
+            method: "POST",
+            headers: {
+                "Content-Type": "application/json",
+                "Authorization": `Bearer ${userToken}`
+            },
+            body: JSON.stringify(bookmarkTree)
+        });
+
+        if (!response.ok) {
+            console.log(response);
+            throw new Error(`응답 상태: ${response.status}`);
+        }
+        
+        // 성공적으로 전송을 마친 뒤에는 hasSynced 플래그를 갱신
+        await chrome.storage.local.set({ hasSynced: true });
+    }
+    catch (error) {
+        console.error(error);
+        return;
+    }
+}
+
+// 북마크 관련 이벤트를 백엔드에 전송
+// onCreated : id(string), bookmark(BookmarkTreeNode)
+// onRemoved : id(string), removeInfo(object)
+// onChanged : id(string), changeInfo(object)
+// onMoved : id(string), moveInfo(object)
+async function syncBookmarkChanges(eventType, id, info) {
+    try {
+        const userToken = await getUserToken();
+        // 삭제 이벤트만 다르게 처리
+        const isRemove = (eventType === "remove");
+        const url = isRemove
+            ? `${API_BASE_URL}/bookmarks/temp1`
+            : `${API_BASE_URL}/bookmarks/temp2`;
+        // 삭제 이벤트는 DELETE, 나머지는 POST
+        const options = {
+            method: isRemove ? "DELETE" : "POST",
+            headers: {
+                "Content-Type": "application/json",
+                "Authorization": `Bearer ${userToken}`
+            },
+            body: JSON.stringify({ eventType, id, info })
+        };
+
+        // 토큰과 이벤트를 백엔드 API 로 전송
+        const response = await fetch(url, options);
+
+        if (!response.ok) {
+            console.log(response);
+            throw new Error(`응답 상태: ${response.status}`);
+        }
+    }
+    catch (error) {
+        console.error(error);
+        return;
+    }
+}
+
+
+
+// ---------- 이벤트 리스너 영역역 ---------- // 
+
+
+
+// 북마크 추가, 삭제, 변경, 이동 이벤트를 정의한 배열
+const bookmarkEvents = [
+    {eventName: chrome.bookmarks.onCreated, eventType: "create"},
+    {eventName: chrome.bookmarks.onRemoved, eventType: "remove"},
+    {eventName: chrome.bookmarks.onChanged, eventType: "change"},
+    {eventName: chrome.bookmarks.onMoved, eventType: "move"}
+];
+
+// 해당 이벤트들은 동일한 콜백 함수로 처리
+bookmarkEvents.forEach(({ eventName, eventType }) => {
+    eventName.addListener(async (id, info) => {
+        // 비동기 함수를 처리할때까지 서비스 워커가 기다려야하므로 await 사용
+        await syncBookmarkChanges(eventType, id, info);
+    })
+});
+
+// 확장 프로그램 프로세스 혹은 컨텐츠 스크립트에서 메시지가 전송될때 실행됨
+chrome.runtime.onMessage.addListener(async message => {
+    switch (message.type) {
+        case "LOGIN_BUTTON_CLICKED":
+            redirectStartPage();
+            break;
+
+        case "MAIN_PAGE_VISTED": {
+            const hasSent = await hasSentAllBookmarks();
+            if (!hasSent)
+                await sendAllBookmarks();
+            break;
+        }
+        default:
+            throw new Error(`정의되지 않은 메시지 타입: ${message.type}`);
+    }
+});
+
+// 다른 확장 프로그램이나 웹 페이지에서 메시지가 전송될 때 실행됨
+chrome.runtime.onMessageExternal.addListener(async message => {
+    switch (message.type) {
+        case "SET_JWT":
+            await storeAccessToken(message);
+            break;
+        default:
+            throw new Error(`정의되지 않은 메시지 타입: ${message.type}`);
+    }
+});


### PR DESCRIPTION
## 🔍 관련 이슈 
Resolve : #80 


## ✅ 작업 내용 요약
1. 신규 유저의 경우, 메인 페이지 접속시 전체 북마크를 가져와 백엔드로 전송합니다.
2. 로컬 브라우저의 북마크 추가/삭제/변경/이동 이벤트 발생시 관련 정보를 백엔드로 전송합니다.




## 💡 변경 사항 상세
- [x] `service_worker.js` : 다음과 같은 작업을 진행
1. `content_script.js` 에서 전송한 메시지를 수신하여 신규 유저라면 전체 북마크를 가져와 백엔드로 전송
2. 로컬 브라우저의 북마크 추가/삭제/변경/이동 이벤트 발생시 관련 정보를 백엔드로 전송
3. 클라이언트에서 로그인 성공시 익스텐션으로 메시지 전송 -> 서비스 워커가 이를 수신하여 `chrome.storage.local` 에 저장

- [x] `content_script.js` : 메인 페이지 접속시 서비스 워커에 메시지를 전송

- [x] `manifest.json` : 다음과 같은 키를 추가하여 권한 획득
1. `content_scripts` : 특정 도메인 (ex. Starlist 메인 페이지) 에서만 `content_script.js` 를 주입하기 위해 추가
2. `host_permissions` : `fetch()` 와 같은 API 로 특정 도메인에 요청을 보내거나 스크립트를 주입하기 위해 추가
3. `externally_connectable` : 웹페이지 혹은 다른 확장프로그램이 우리 확장프로그램과 통신 (ex. `runtime.connect()` 혹은`runtime.sendMessage` 를 사용) 하기 위해 추가
4. `key` : 현재 이 부분은 추가되어있지 않음.
- 이유 : 백엔드 서버의 CORS 정책을 위해서 확장프로그램 고유 ID 를 필요로 함. 이때 ID 를 일관되게 유지하기 위해 `key` 를 설정함. 하지만, 이 속성의 값은 RSA public key 를 사용하는데 실수로 private key 로 설정을 해서 현재 삭제해놓은 상태임. 공개키를 발급받기 위해서 가장 확실한 방법은 크롬 스토어에 배포를 하는 것이므로 배포 전까지는 이를 설정하지 않을 예정





## 🧪 테스트 결과
- 전체 북마크 전송 기능은 백엔드와 연동 완료 
- 북마크 이벤트 발생 처리 기능은 아직 백엔드와 연동하지 않음


## 🔒 기타 참고 사항
- 북마크 관련 기능들을 구현했을뿐만 아니라 전체적인 코드 리팩토링도 같이 진행하였다는 점 양해 바랍니다.
- 위에서 언급하였지만, 지금 `manifest.json` 의 `key` 부분이 빠져있기 때문에 압축 해제된 빌드 폴더를 확장프로그램에 업로드하여 사용하더라도 확장프로그램의 ID 가 고정이 되지 않으므로 백엔드 통신 (CORS 문제) 과 웹페이지 통신 (sendMessage) 이 안된다는 점 인지하시면 되겠습니다.  
