### PR TITLE
로그인 여부에 따른 라우팅 문제 해결

### DIFF
--- a/client/src/pages/AuthSuccessPage.jsx
+++ b/client/src/pages/AuthSuccessPage.jsx
@@ -6,7 +6,7 @@ const EXT_ID = import.meta.env.VITE_EXTENSION_ID;
 
 const AuthSuccessPage = () => {
     const navigate = useNavigate();
-    const login = useAuthStore((state) => state.login); // 로그인 상태 갱신 함수
+    const { login } = useAuthStore(); // 로그인 상태 갱신 함수
 
     useEffect(() => {
         const params = new URLSearchParams(window.location.search);
@@ -32,10 +32,10 @@ const AuthSuccessPage = () => {
             window.history.replaceState(null, "", import.meta.env.VITE_GOOGLE_AUTH_URI.replace(/.*\/\/[^/]+/, ""))
 
             // 메인 페이지로 이동
-            navigate("/main");
+            navigate("/main", { replace: true });
         } else {
             // 토큰이 없는 경우 로그인 페이지로 회귀 
-            navigate("/login");
+            navigate("/start", { replace: true });
         }
     }, [navigate, login]);
 

--- a/client/src/store/useAuthStore.js
+++ b/client/src/store/useAuthStore.js
@@ -1,9 +1,13 @@
 import { create } from "zustand";
+import { persist } from "zustand/middleware";
 
-const useAuthStore = create((set) => ({
-    isLoggedIn: false,
-    login: () => set({ isLoggedIn: true }),
-    logout: () => set({ isLoggedIn: false }),
-}));
+const useAuthStore = create(persist(
+    (set) => ({
+        isLoggedIn: false,
+        login: () => set({ isLoggedIn: true }),
+        logout: () => set({ isLoggedIn: false }),
+    }),
+    { name: "auth-storage" }
+));
 
 export default useAuthStore;


### PR DESCRIPTION
## 🔍 관련 이슈 
<!-- 관련된 이슈 번호를 연결하세요 (예: #23) -->
Resolve : #78


## ✅ 작업 내용 요약
<!-- 어떤 작업을 했는지 한두 문장으로 요약해주세요 -->
기존에 로그인 여부에 따라 main or start 페이지로 라우팅 되도록 구현하였지만, 정상적으로 작동하지 않는 문제 해결




## 💡 변경 사항 상세
<!-- 어떤 파일이 변경되었고, 주요 변경사항은 무엇인지 설명해주세요 -->
`useAuthStore.js`: zustand의 persist 미들웨어를 사용하여 로그인 상태가 전역 storage에 저장하도록 함
`AuthSuccessPage.jsx`: 과거에 존재 했으나, 이제는 존재하지 않는 `/login`로 라우팅하는 부분을 로그인X 시 start 페이지로 이동하도록 수정

