### PR TITLE
chore: 필요 없는 권한 삭제

### DIFF
--- a/extension/public/manifest.json
+++ b/extension/public/manifest.json
@@ -34,7 +34,6 @@
     "matches": ["https://sstarlist.netlify.app/*"]
   },
   "permissions": [
-    "tabs",
     "storage",
     "bookmarks"
   ]


### PR DESCRIPTION
## ✅ 작업 내용 요약
- 배포 과정에서 필요 없는 권한을 `manifest.json` 에서 선언하고 있어 거절이 되었습니다.
- 따라서, 필요 없는 권한인 `tabs` 을 제거하였습니다.





## 💡 변경 사항 상세
- `manifest.json` : `tabs` 권한 삭제


## 📸 스크린샷
![image](https://github.com/user-attachments/assets/435c5429-6c6a-4f96-9d70-5608f7fa8d2c)


