### PR TITLE
chore: MainPage → CardList 로직 이동

### DIFF
--- a/client/src/components/bookmark/BookmarkCard.jsx
+++ b/client/src/components/bookmark/BookmarkCard.jsx
@@ -1,16 +1,14 @@
+import React from "react";
 import ToggleButton from "./ToggleButton";
 
 /**
  * 북마크 카드 컴포넌트
- * @param {string} title 
- * @param {string} url
+ * @param {object} info // 북마크 정보
  * @param {boolean} selected   // 부모가 넘겨줄 선택 상태
  * @param {() => void} onToggle // 부모가 넘겨줄 토글 핸들러
  */
 
-
-
-const BookmarkCard = ({ title, url, selected, onToggle }) => { // 시간 필요시 image,dataAdded prop 추가
+const BookmarkCard = ({ info, selected, onToggle }) => { // 시간 필요시 image,dataAdded prop 추가
     /*
     const formattedTime = new Date(dataAdded * 1000).toLocaleTimeString("ko-KR", {
         hour: "2-digit",
@@ -45,14 +43,14 @@ const BookmarkCard = ({ title, url, selected, onToggle }) => { // 시간 필요�
             </div>
             {/* 제목 */}
             <a
-                href={url}
+                href={info.url}
                 target="_blank"
                 rel="noopener noreferrer"
                 className="w-full text-base sm:text-lg md:text-xl 
                         font-semibold text-left
                          text-main-black truncate" // turncate는 제목이 너무 길어지면 뒷부분을 ... 으로 처리
             >
-                {title}
+                {info.title}
             </a>
 
             {/* 시간 

--- a/client/src/components/cardlist/CardList.jsx
+++ b/client/src/components/cardlist/CardList.jsx
@@ -1,10 +1,21 @@
-import React from "react";
+import React, { useState } from "react";
 import { useGetNodes } from "../../functions/hooks/useGetNodes";
+import Header from "../header/Header";
 import BookmarkCard from "../bookmark/BookmarkCard";
 import FolderCard from "FolderCard";
 
+
 const CardList = () => {
     const { data, status, error } = useGetNodes();
+    const [selectedIds, setSelectedIds] = useState([]);
+
+    const toggle = id => {
+        setSelectedIds(prev =>
+            prev.includes(id)
+                ? prev.filter(x => x !== id)
+                : [...prev, id]
+        );
+    };
 
     if (status === "error")
         return <p>에러 발생: {error.message}</p>
@@ -12,13 +23,22 @@ const CardList = () => {
     return (
         <div className="max-w-screen-[1520px] mx-auto px-[150px] py-[150px]">
             <div className="mt-6 grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6">
-                {data.map(item => (
-                    item.url === null
-                        ? <FolderCard/>
-                        : <BookmarkCard/>
+                {data.map(node => (
+                    node.url === null
+                        ? <FolderCard
+                            key={node.id}
+                            info={node}
+                            />
+                        : <BookmarkCard
+                            key={node.id} 
+                            info={node}
+                            selected={selectedIds.includes(node.id)}
+                            onToggle={() => toggle(node.id)}
+                            />
                 ))}
             </div>
         </div>
     )
-
 }
+
+export { CardList };

--- a/client/src/pages/MainPage.jsx
+++ b/client/src/pages/MainPage.jsx
@@ -1,52 +1,12 @@
-import React, { useEffect, useState } from "react";
-import useBookmarkStore from "../functions/hooks/useBookmarkStore";
-import { fetchBookmarks } from "../functions/utils/bookmarkApi";
+import React from "react";
 import Header from "../components/header/Header";
-import BookmarkCard from "../components/bookmark/BookmarkCard";
+import { CardList } from "../components/cardlist/CardList";
 
 const MainPage = () => {
-    const { bookmarks, setBookmarks } = useBookmarkStore(); // 북마크 관리
-    const [selectedIds, setSelectedIds] = useState([]); // 사용자가 선택한 북마크의 ID목록 저장
-
-
-    useEffect(() => {
-        (async () => {
-            try {
-                const data = await fetchBookmarks();
-                setBookmarks(data);
-            } catch (e) {
-                console.error(e);
-            }
-        })();
-    }, [setBookmarks]);
-
-
-    const toggle = id => {
-        setSelectedIds(prev =>
-            prev.includes(id)
-                ? prev.filter(x => x !== id)
-                : [...prev, id]
-        );
-    };
-
     return (
         <div>
             <Header />
-            <div className="max-w-screen-[1520px] mx-auto px-[150px] py-[150px]">
-                {/* --- 카드 그리드 --- */}
-                <div className="mt-6 grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6">
-                    {bookmarks.map(bookmark => (
-                        <BookmarkCard
-                            key={bookmark.id}
-                            title={bookmark.title}
-                            url={bookmark.url}
-                            selected={selectedIds.includes(bookmark.id)}
-                            onToggle={() => toggle(bookmark.id)}
-                        />
-                    ))}
-                </div>
-            </div>
-
+            <CardList/>
         </div>
     );
 };


### PR DESCRIPTION
## 🔍 관련 이슈 
Resolve : #


## ✅ 작업 내용 요약
<!-- 어떤 작업을 했는지 한두 문장으로 요약해주세요 -->
- 확장프로그램 연동 테스트를 위해 netlify 의 EXT_ID 값을 고정하였습니다.
- 테스트를 위해서는 netlify 배포가 되어야 하는데 이전에 작업했던 기능이 완벽하게 적용되지 않아서 이를 수정하였습니다.





## 💡 변경 사항 상세
<!-- 어떤 파일이 변경되었고, 주요 변경사항은 무엇인지 설명해주세요 -->
- `MainPage` : 이전의 로직과 CSS 설정을 `CardList` 로 이전 + 쓰지 않는 변수와 함수를 제거
- `CardList` : `MainPage` 로직을 반영
- `BookmarkCard` : 기존에는 props 로 title, url 등을 바로 전달하였지만 info 객체를 전달하여 내부에서 title, url 을 분해하여 사용
