### PR TITLE
QueryClient 추가와 주입

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -8,36 +8,40 @@ import NotFoundPage from "./pages/NotFoundPage";
 import AuthSuccessPage from "./pages/AuthSuccessPage";
 import PrivatePolicyPage from "./pages/PrivatePolicyPage";
 import SettingPage from "./pages/SettingPage";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 
 const App = () => {
   const { isLoggedIn } = useAuthStore(); // Zustand 스토어에서 로그인 상태 가져오기
+  const queryClient = new QueryClient();
 
   return (
-    <Routes>
-      {/* 로그인 여부에 따라 시작 페이지를 다르게 설정 */}
-      <Route
-        path="/"
-        element={
-          isLoggedIn
-            ? <Navigate to="/main" replace />
-            : <Navigate to="/start" replace />
-        }
-      />
-      {/*익스텐션 개인정보처리방침 페이지 */}
-      <Route path="/policy" element={<PrivatePolicyPage />} />
-      {/* 로그인 완료 후 처리 페이지 */}
-      <Route path="/auth/success" element={<AuthSuccessPage />} />
+    <QueryClientProvider client={queryClient}>
+      <Routes>
+        {/* 로그인 여부에 따라 시작 페이지를 다르게 설정 */}
+        <Route
+          path="/"
+          element={
+            isLoggedIn
+              ? <Navigate to="/main" replace />
+              : <Navigate to="/start" replace />
+          }
+        />
+        {/*익스텐션 개인정보처리방침 페이지 */}
+        <Route path="/policy" element={<PrivatePolicyPage />} />
+        {/* 로그인 완료 후 처리 페이지 */}
+        <Route path="/auth/success" element={<AuthSuccessPage />} />
 
-      {/* 메인 페이지 */}
-      <Route path="/main" element={<MainPage />} />
+        {/* 메인 페이지 */}
+        <Route path="/main" element={<MainPage />} />
 
-      {/* 시작(로그인) 페이지 */}
-      <Route path="/start" element={<StartPage />} />
-      {/* 설정 페이지 */}
-      <Route path="/setting" element={<SettingPage />} />
-      {/* 그 외 404 페이지 */}
-      <Route path="*" element={<NotFoundPage />} />
-    </Routes>
+        {/* 시작(로그인) 페이지 */}
+        <Route path="/start" element={<StartPage />} />
+        {/* 설정 페이지 */}
+        <Route path="/setting" element={<SettingPage />} />
+        {/* 그 외 404 페이지 */}
+        <Route path="*" element={<NotFoundPage />} />
+      </Routes>
+    </QueryClientProvider>
   );
 };
 

--- a/client/src/components/cardlist/CardList.jsx
+++ b/client/src/components/cardlist/CardList.jsx
@@ -6,7 +6,7 @@ import FolderCard from "./FolderCard";
 
 
 const CardList = () => {
-    const { data, status, error } = useGetNodes();
+    const { data = [], status, error } = useGetNodes();
     const [selectedIds, setSelectedIds] = useState([]);
 
     const toggle = id => {


### PR DESCRIPTION
## 🔍 관련 이슈 
<!-- 관련된 이슈 번호를 연결하세요 (예: #23) -->
Resolve : #


## ✅ 작업 내용 요약
<!-- 어떤 작업을 했는지 한두 문장으로 요약해주세요 -->
- React Query 의 기능들을 사용하기 위해서는 QueryClient 객체가 필요한데 이를 `App` 에 선언
- 어플리케이션 전역에서 QueryClient 를 접근하기 위해서 `<QueryClientProvider/>` 로 감싸서 선언한 QueryClient 객체를 주입 
- `CardList` 에서 `useGetNodes()` 로 가져온 데이터가 없다면 에러가 나서 `MainPage` 전체가 렌더링되지 않는 현상 발생. 이를 해결하기 위해 데이터에 빈 배열을 기본값으로 설정