### PR TITLE
API 호출시 토큰 가져오기 로직 수정

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1,6 +1,7 @@
 import React from "react";
-import { Routes, Route, Navigate } from "react-router-dom";
-import useAuthStore from "./functions/hooks/useAuthStore"; // 로그인 상태가 저장되어 있는 훅스
+import { BrowserRouter, Routes, Route, Navigate } from "react-router-dom";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { useAuth, AuthProvider } from "./context/AuthContext";
 
 import MainPage from "./pages/MainPage";
 import StartPage from "./pages/StartPage";
@@ -8,39 +9,72 @@ import NotFoundPage from "./pages/NotFoundPage";
 import AuthSuccessPage from "./pages/AuthSuccessPage";
 import PrivatePolicyPage from "./pages/PrivatePolicyPage";
 import SettingPage from "./pages/SettingPage";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+// React-Query 사용을 위한 QueryClient 객체 선언
+const queryClient = new QueryClient();
+
+// 로그아웃 상태일때에는 시작 페이지로 라우팅
+const ProtectedRoute = ({ children }) => {
+    const { isLoggedIn } = useAuth();
+    return isLoggedIn ? children : <Navigate to="/start" replace />;
+};
+
+// 로그인 상태일때에는 메인 페이지로 라우팅
+const PublicRoute = ({ children }) => {
+    const { isLoggedIn } = useAuth();
+    return !isLoggedIn ? children : <Navigate to="/main" replace />;
+};
+
+const AppRoutes = () => (
+  <Routes>
+    {/* 루트 페이지 */}
+    <Route path="/" element={
+      <PublicRoute>
+        <StartPage />
+      </PublicRoute>
+    }/>
+
+    {/* 개인정보처리방침 페이지 */}
+    <Route path="/policy" element={<PrivatePolicyPage />} />
+
+    {/* 로그인 완료 후 처리 페이지 */}
+    <Route path="/auth/success" element={<AuthSuccessPage />} />
+
+    {/* 메인 페이지 */}
+    <Route path="/main" element={
+      <ProtectedRoute>
+        <MainPage />
+      </ProtectedRoute>
+    }/>
+
+    {/* 시작 페이지 */}
+    <Route path="/start" element={
+      <PublicRoute>
+        <StartPage />
+      </PublicRoute>
+    }/>
+
+    {/* 설정 페이지 */}
+    <Route path="/setting" element={
+      <ProtectedRoute>
+        <SettingPage />
+      </ProtectedRoute>
+    }/>
+
+    {/* 404 페이지 */}
+    <Route path="*" element={<NotFoundPage />} />
+  </Routes>
+);
+
 
 const App = () => {
-  const { isLoggedIn } = useAuthStore(); // Zustand 스토어에서 로그인 상태 가져오기
-  const queryClient = new QueryClient();
-
   return (
     <QueryClientProvider client={queryClient}>
-      <Routes>
-        {/* 로그인 여부에 따라 시작 페이지를 다르게 설정 */}
-        <Route
-          path="/"
-          element={
-            isLoggedIn
-              ? <Navigate to="/main" replace />
-              : <Navigate to="/start" replace />
-          }
-        />
-        {/*익스텐션 개인정보처리방침 페이지 */}
-        <Route path="/policy" element={<PrivatePolicyPage />} />
-        {/* 로그인 완료 후 처리 페이지 */}
-        <Route path="/auth/success" element={<AuthSuccessPage />} />
-
-        {/* 메인 페이지 */}
-        <Route path="/main" element={<MainPage />} />
-
-        {/* 시작(로그인) 페이지 */}
-        <Route path="/start" element={<StartPage />} />
-        {/* 설정 페이지 */}
-        <Route path="/setting" element={<SettingPage />} />
-        {/* 그 외 404 페이지 */}
-        <Route path="*" element={<NotFoundPage />} />
-      </Routes>
+      <BrowserRouter>
+        <AuthProvider>
+          <AppRoutes />
+        </AuthProvider>
+      </BrowserRouter>
     </QueryClientProvider>
   );
 };

--- a/client/src/context/AuthContext.jsx
+++ b/client/src/context/AuthContext.jsx
@@ -1,0 +1,35 @@
+import React, { createContext, useContext, useState, useEffect } from "react";
+import useAuthStore from "../functions/hooks/useAuthStore";
+
+// 로그인, 로그아웃 관련 Context 생성
+const AuthContext = createContext();
+
+// 해당 Context 를 제공하는 컴포넌트
+const AuthProvider = ({ children }) => {
+    const { accessToken, login, logout } = useAuthStore();
+    const [isLoggedIn, setIsLoggedIn] = useState(!!accessToken);
+
+    // Zustand store의 token 변화에 따라 isLoggedIn 상태 동기화
+    useEffect(() => {
+        setIsLoggedIn(!!accessToken);
+    }, [accessToken]);
+
+    return (
+        <AuthContext.Provider value={{ isLoggedIn, accessToken, login, logout }}>
+            {children}
+        </AuthContext.Provider>
+    );
+};
+
+// Context 사용을 위한 Hook
+const useAuth = () => {
+  const context = useContext(AuthContext);
+
+  // 만약 Context Provider 바깥에서 이 Hook 을 호출하면 에러를 반환
+  if (!context)
+    throw new Error('useAuth must be used within AuthProvider');
+
+  return context;
+};
+
+export { AuthProvider, useAuth };

--- a/client/src/functions/hooks/useAuthStore.js
+++ b/client/src/functions/hooks/useAuthStore.js
@@ -1,16 +1,19 @@
 import { create } from "zustand";
 
-const useAuthStore = create((set) => ({
-    isLoggedIn: false,
-    accessToken: null,
-    login: (token) => set({
-        isLoggedIn: true,
-        accessToken: token,
-    }),
-    logout: () => set({
-        isLoggedIn: false,
-        accessToken: null
-    }),
-}));
+const useAuthStore = create((set) => {
+  const token = sessionStorage.getItem("accessToken");
+
+  return {
+    accessToken: token,
+    login: (token) => {
+      sessionStorage.setItem("accessToken", token);
+      set({ accessToken: token });
+    },
+    logout: () => {
+      sessionStorage.removeItem("accessToken");
+      set({ accessToken: null });
+    },
+  };
+});
 
 export default useAuthStore;

--- a/client/src/main.jsx
+++ b/client/src/main.jsx
@@ -1,13 +1,10 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
-import { BrowserRouter } from "react-router-dom";
 import App from "./App";
 import "./styles/index.css";
 
 createRoot(document.getElementById("root")).render(
   <StrictMode>
-    <BrowserRouter>
       <App />
-    </BrowserRouter>
   </StrictMode>
 );

--- a/client/src/pages/AuthSuccessPage.jsx
+++ b/client/src/pages/AuthSuccessPage.jsx
@@ -10,30 +10,28 @@ const AuthSuccessPage = () => {
 
     useEffect(() => {
         const params = new URLSearchParams(window.location.search);
-        const access_token = params.get("token");
+        const accessToken = params.get("token");
         const hasSynced = params.get("hasSynced") === "true";
 
-        if (access_token) {
+        if (accessToken) {
             // 익스텐션에 메시지 전달
             if (window.chrome?.runtime?.sendMessage) {
                 window.chrome.runtime.sendMessage(EXT_ID, {
                     type: "SET_JWT",
-                    token: access_token,
+                    token: accessToken,
                     hasSynced,
                 });
             }
-            // 로컬 스토리지에 토큰 저장
-            localStorage.setItem("accessToken", access_token);
-
             // 로그인 상태 저장
-            login(access_token);
+            login(accessToken);
 
             // 주소창에서 token 제거 (보안을 위해서!)
             window.history.replaceState(null, "", import.meta.env.VITE_GOOGLE_AUTH_URI.replace(/.*\/\/[^/]+/, ""))
 
             // 메인 페이지로 이동
             navigate("/main", { replace: true });
-        } else {
+        } 
+        else {
             // 토큰이 없는 경우 로그인 페이지로 회귀 
             navigate("/start", { replace: true });
         }


### PR DESCRIPTION
## 🔍 관련 이슈 
Resolve : #


## ✅ 작업 내용 요약
<!-- 어떤 작업을 했는지 한두 문장으로 요약해주세요 -->
- 토큰을 가져오는 과정에서 Zustand 의 전역 상태에 저장된 토큰을 가져오다보니 새로고침(F5) 를 눌렀을때 상태값이 null 값으로 초기화되는 문제가 발생하였습니다.
- 이에 따라서 백엔드 서버에서는 유효하지 않은 토큰에 대해서 302 응답을 반환하다보니 백그라운드에서 로그인 URL 로 리다이렉트되어 리다이렉트된 URL 에서 fetch 를 하게되면서 CORS 오류가 발생하였습니다.
- 따라서 새로고침을 하더라도 정상적으로 Zustand 전역 상태를 통해 토큰을 가져올 수 있도록 변경하였습니다. 
- Storage 에서 직접적으로 토큰값을 가져올 수 있지만 그 경우에는 Storage 업데이트에 따른 UI 도 변화하여야 하는데 이를 관리하는 것은 쉽지 않습니다. 따라서 Zustand 를 사용한다면 이에 따른 UI 변화도 관리가 용이해집니다.
- 로그인/로그아웃 상태에 따라서 접근 가능한 페이지 또한 달라지므로 `App` 의 라우팅 설정을 수정하였습니다.
- 로그인/로그아웃 상태를 필요로 하는 컴포넌트가 많으므로 이를 Context 를 사용하여 처리하도록 `AuthContext` 를 추가하였습니다.
