### PR TITLE
Swagger가 RestControllerAdvice를 API로 파싱하지 않도록 개선

### DIFF
--- a/server/src/main/java/wap/starlist/error/GlobalExceptionHandler.java
+++ b/server/src/main/java/wap/starlist/error/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package wap.starlist.error;
 
+import io.swagger.v3.oas.annotations.Hidden;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -10,6 +11,7 @@ import wap.starlist.error.exception.BookmarkNotFoundException;
 import wap.starlist.error.exception.NotFoundException;
 
 @Slf4j
+@Hidden
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 


### PR DESCRIPTION
- 3001 응답을 받은 클라이언트는 사용자의 북마크 정보를 서버와 동기화해야 한다.

## 🔍 관련 이슈 
<!-- 관련된 이슈 번호를 연결하세요 (예: #23) -->
Resolve : #


## ✅ 작업 내용 요약
<!-- 어떤 작업을 했는지 한두 문장으로 요약해주세요 -->
- commit 메시지를 수정하지 못했습니다..
- `@Hidden` 어노테이션을 통해 swagger가 RestControllerAdvice까지 파싱하려고 하는 것을 막았습니다





## 💡 변경 사항 상세
<!-- 어떤 파일이 변경되었고, 주요 변경사항은 무엇인지 설명해주세요 -->
- 
- 



<!--
## 🧪 테스트 결과
어떤 테스트를 했고, 결과가 어땠는지 적어주세요
- [ ] 로컬에서 테스트 완료
- [ ] 관련 테스트 코드 수정/추가
- [ ] CI 통과 확인

---


## 📸 스크린샷 (선택)
UI 작업일 경우, 변경된 화면 캡처를 첨부해주세요 
---

## 🔒 기타 참고 사항
리뷰어가 알아야 할 추가 정보가 있다면 적어주세요 (ex: 주의할 점, 트러블슈팅 등) 

---

## 🙏 리뷰어에게 바라는 점
어떤 부분을 중점적으로 봐주면 좋을지 적어주세요 (선택) 
- ex) 성능 개선이 잘 되었는지 봐주세요

-->
