### PR TITLE
fix: 전역 상태 변경에 따른 렌더링 오류 수정 1

### DIFF
--- a/client/src/components/CardList/BookmarkCard.jsx
+++ b/client/src/components/CardList/BookmarkCard.jsx
@@ -1,24 +1,14 @@
 import React from "react";
+
+import { useCardSelection } from "../../context/CardSelectionContext";
+
 import ToggleButton from "./ToggleButton";
 
-/**
- * 북마크 카드 컴포넌트
- * @param {object} info // 북마크 정보
- * @param {boolean} selected   // 부모가 넘겨줄 선택 상태
- * @param {() => void} onToggle // 부모가 넘겨줄 토글 핸들러
- */
-
-const BookmarkCard = ({ info, selected, onToggle }) => { // 시간 필요시 image,dataAdded prop 추가
-    /*
-    const formattedTime = new Date(dataAdded * 1000).toLocaleTimeString("ko-KR", {
-        hour: "2-digit",
-        minute: "2-digit",
-    });
-    
-    */
+const BookmarkCard = ({ info }) => {
+    const { selectedCards, toggle } = useCardSelection();
+    const selected = selectedCards.includes(info.id);
 
     return (
-
         <div className={`relative w-full sm:max-w-[280px] md:max-w-[320px] lg:max-w-[366px] aspect-[3/2] 
                             rounded-[39px] bg-white shadow-card
                             p-4 flex flex-col justify-end group transition-colors duration-200
@@ -38,8 +28,8 @@ const BookmarkCard = ({ info, selected, onToggle }) => { // 시간 필요시 ima
                 }`
             }>
                 <ToggleButton
-                    selected={selected}
-                    onClick={onToggle} />
+                    selected={selectedCards}
+                    onClick={() => toggle(info.id)} />
             </div>
             {/* 제목 */}
             <a
@@ -52,13 +42,6 @@ const BookmarkCard = ({ info, selected, onToggle }) => { // 시간 필요시 ima
             >
                 {info.title}
             </a>
-
-            {/* 시간 
-                <span className="text-[22px] font-medium text-[#8d87a2] whitespace-nowrap">
-                    {formattedTime}
-                </span>
-                */}
-
         </div>
     );
 }

--- a/client/src/components/CardList/BreadCrumb.jsx
+++ b/client/src/components/CardList/BreadCrumb.jsx
@@ -9,12 +9,17 @@ const BreadCrumb = () => {
     const stack = useFolderPathStore(state => state.stack);
     const move = useFolderPathStore(state => state.move);
     
+    const handleNavigation = (id) => {
+        move(id);
+        setCurrentPosition(id); 
+    }
+
     return (
         <div className="flex justify-center space-x-2">
-            {stack.map(({ id, title }) => (
+            {stack.map(({ id, title }, index) => (
                 <div key={id} className="flex items-center">
-                    <span onClick={() => { move(id); setCurrentPosition(id); }}>{title}</span>
-                    {stack.at(stack.length - 1) !== id && <ArrowForwardIcon/>}
+                    <span onClick={() => handleNavigation(id)}>{title}</span>
+                    {index < stack.length - 1 && <ArrowForwardIcon/>}
                 </div>
             ))}
         </div>

--- a/client/src/components/CardList/CardList.jsx
+++ b/client/src/components/CardList/CardList.jsx
@@ -1,30 +1,15 @@
 import React from "react";
-import { useGetNodes } from "../../functions/hooks/useGetNodes";
-import useAuthStore from "../../functions/hooks/useAuthStore";
 
 import { CardSelectionContextProvider } from "../../context/CardSelectionContext";
 import Toolbar from "./Toolbar";
 import CardsContainer from "./CardsContainer";
 
 const CardList = () => {
-    const { data = [], status, error } = useGetNodes();
-    const logout = useAuthStore(state => state.logout);
-
-    if (status === "error" && error.code === 2002) {
-        // 유효하지 않은 토큰이라면
-        logout();
-        return null;
-    }
-
     return (
         <div className="flex flex-col max-w-screen-[1520px] mx-auto px-[150px] py-[150px]">
             <Toolbar/>
             <CardSelectionContextProvider>
-                <CardsContainer
-                    nodes={data}
-                    status={status}
-                    error={error}
-                />
+                <CardsContainer/>
             </CardSelectionContextProvider>
         </div>
     );

--- a/client/src/components/CardList/CardsContainer.jsx
+++ b/client/src/components/CardList/CardsContainer.jsx
@@ -1,24 +1,26 @@
-import React, { useState } from "react";
+import React from "react";
+import { useAuth } from "../../context/AuthContext";
+import useCurrentPositionStore from "../../functions/hooks/useCurrentPositionStore";
+import useGetNodes from "../../functions/hooks/useGetNodes";
 
 import BookmarkCard from "./BookmarkCard";
 import FolderCard from "./FolderCard";
 
-const CardsContainer = ({ nodes, status, error }) => { 
-    const [selectedIds, setSelectedIds] = useState([]);
-
-    const toggle = id => {
-        setSelectedIds(prev =>
-            prev.includes(id)
-                ? prev.filter(x => x !== id)
-                : [...prev, id]
-        );
-    };
+const CardsContainer = () => {
+    const folderId = useCurrentPositionStore(state => state.currentPosition);
+    const { data = [], status, error } = useGetNodes(folderId);
+    console.log(data);  // 디버깅용
+    const { logout } = useAuth();
 
     if (status === "loading")
         return <p>로딩중...</p>;
 
     if (status === "error") {
         switch(error.code) {
+            // 유효하지 않은 토큰이라면
+            case 2002:
+                logout();
+                return null;
             // 데이터가 없다면
             case 3001:
                 return <p>아무 것도 없네요</p>;
@@ -31,19 +33,15 @@ const CardsContainer = ({ nodes, status, error }) => {
     // 정상적으로 데이터를 받아온다면
     return (
         <div className="mt-6 grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6">
-            {nodes.map(node => (
+            {data.map(node => (
                 node.url === null
                     ? <FolderCard
                         key={node.id}
                         info={node}
-                        selected={selectedIds.includes(node.id)}
-                        onToggle={() => toggle(node.id)}
                         />
                     : <BookmarkCard
                         key={node.id} 
                         info={node}
-                        selected={selectedIds.includes(node.id)}
-                        onToggle={() => toggle(node.id)}
                         />
             ))}
         </div>

--- a/client/src/components/CardList/FolderCard.jsx
+++ b/client/src/components/CardList/FolderCard.jsx
@@ -1,10 +1,10 @@
 import React from "react";
 import useCurrentPositionStore from "../../functions/hooks/useCurrentPositionStore";
-import useFolderStackStore from "../../functions/hooks/useFolderPathStore";
+import useFolderPathStore from "../../functions/hooks/useFolderPathStore";
 
 const FolderCard = ({ info }) => {
     const setCurrentPosition = useCurrentPositionStore(state => state.setCurrentPosition);
-    const push = useFolderStackStore(state => state.push);
+    const push = useFolderPathStore(state => state.push);
 
     const onClick = () => {
         push({ id: info.id, title: info.title });

--- a/client/src/functions/hooks/useGetNodes.js
+++ b/client/src/functions/hooks/useGetNodes.js
@@ -1,20 +1,16 @@
 import { useQuery, keepPreviousData } from "@tanstack/react-query";
-import { getNodesByFolderId } from "../utils/getNodesByFolderId";
-import useCurrentPositionStore from "./useCurrentPositionStore";
-import { getRootNodes } from "../utils/getRootNodes";
+import getNodesByFolderId from "../utils/getNodesByFolderId";
+import getRootNodes from "../utils/getRootNodes";
 
 // 백엔드로부터 가져온 리스트를 React Query 를 사용하여
 // 캐싱, 변경 추적, 최신화를 가능하게 하는 함수
-function useGetNodes() {
-    // 현재 폴더 위치 상태를 구독
-    const currentPosition = useCurrentPositionStore(state => state.currentPosition);
-
+function useGetNodes(folderId) {
     return useQuery({
-        queryKey: ["nodes", currentPosition],
+        queryKey: ["nodes", folderId],
         queryFn: () => {
-            return currentPosition === 0
+            return folderId === 0
                 ? getRootNodes()
-                : getNodesByFolderId(currentPosition);
+                : getNodesByFolderId(folderId);
         },
 
         // 캐시된 데이터가 언제까지 "fresh" 상태인지를 나타내는 옵션 (fresh 하지 않다면 refetch)
@@ -36,4 +32,4 @@ function useGetNodes() {
     });
 }
 
-export { useGetNodes };
+export default useGetNodes;

--- a/client/src/functions/utils/fetchNodesByPath.js
+++ b/client/src/functions/utils/fetchNodesByPath.js
@@ -22,4 +22,4 @@ async function fetchNodesByPath(path) {
     return response.json();
 }
 
-export { fetchNodesByPath };
+export default fetchNodesByPath;

--- a/client/src/functions/utils/getNodesByFolderId.js
+++ b/client/src/functions/utils/getNodesByFolderId.js
@@ -1,4 +1,4 @@
-import { fetchNodesByPath } from "./fetchNodesByPath";
+import fetchNodesByPath from "./fetchNodesByPath";
 
 // 현재 폴더 위치에 해당하는 노드 리스트를 반환하는 함수
 // 이 함수는 useQuery 의 queryFn 값으로 쓰임
@@ -7,4 +7,4 @@ async function getNodesByFolderId(folderId) {
     return await fetchNodesByPath(`/folders/children/${folderId}`);
 }
 
-export { getNodesByFolderId };
+export default getNodesByFolderId;

--- a/client/src/functions/utils/getRootNodes.js
+++ b/client/src/functions/utils/getRootNodes.js
@@ -1,4 +1,4 @@
-import { fetchNodesByPath } from "./fetchNodesByPath";
+import fetchNodesByPath from "./fetchNodesByPath";
 import ApiError from "./ApiError";
 
 const EXT_ID = import.meta.env.VITE_EXTENSION_ID;
@@ -23,4 +23,4 @@ async function getRootNodes() {
     }
 }
 
-export { getRootNodes };
+export default getRootNodes;


### PR DESCRIPTION
## 🔍 관련 이슈 
<!-- 관련된 이슈 번호를 연결하세요 (예: #23) -->
Resolve : #


## ✅ 작업 내용 요약
<!-- 어떤 작업을 했는지 한두 문장으로 요약해주세요 -->
- `BreadCrumb` 를 사용할때 빠르게 폴더를 왔다 갔다하면 이전 데이터 + 현재 데이터가 일시적으로 혼재되어 보이는 현상이 발생하였습니다.
- 이를 해결하기 위해서는 로컬 서버에서는 진행할 수 없으므로 PR 을 여러번 해보면서 테스트를 진행해야할 것 같습니다.



## 📸 스크린샷
![스크린샷 2025-05-25 110847](https://github.com/user-attachments/assets/69afd31a-070a-4582-bd36-de86dd373f87)

