### PR TITLE
북마크 동기화 속도 개선

### DIFF
--- a/server/src/main/java/wap/starlist/bookmark/controller/BookmarkController.java
+++ b/server/src/main/java/wap/starlist/bookmark/controller/BookmarkController.java
@@ -92,7 +92,7 @@ public class BookmarkController {
         try {
 
             // Root-Folder-Bookmark의 연관관계 설정 및 적용
-            Root unlinkedRoot = bookmarkService.saveAll(bookmarkTreeNodes);
+            Root unlinkedRoot = bookmarkService.saveAll(bookmarkTreeNodes, loginUser);
 
             log.info("Root를 제외한 연관관계 설정 완료");
             // Root-Member의 연관관계 설정 및 적용

--- a/server/src/main/java/wap/starlist/bookmark/domain/Bookmark.java
+++ b/server/src/main/java/wap/starlist/bookmark/domain/Bookmark.java
@@ -20,6 +20,7 @@ public class Bookmark {
 
     private String summary;
 
+    @Column(length = 2048)
     private String image;
 
     private String recommended;

--- a/server/src/main/java/wap/starlist/bookmark/domain/Folder.java
+++ b/server/src/main/java/wap/starlist/bookmark/domain/Folder.java
@@ -45,6 +45,7 @@ public class Folder {
     @JoinColumn(name ="parent_id")
     private Folder parent;
 
+    @Builder.Default
     @OneToMany(mappedBy = "parent", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Folder> folders = new ArrayList<>();
 
@@ -56,6 +57,10 @@ public class Folder {
         for (Folder child : folders) {
             child.setParent(this);
         }
+    }
+
+    public void addChildFolder(Folder child) {
+        this.folders.add(child);
     }
 
     public void updateChildBookmarks(List<Bookmark> bookmarks) {

--- a/server/src/main/java/wap/starlist/bookmark/dto/request/BookmarkTreeNode.java
+++ b/server/src/main/java/wap/starlist/bookmark/dto/request/BookmarkTreeNode.java
@@ -10,7 +10,6 @@ import wap.starlist.bookmark.domain.Folder;
 import wap.starlist.bookmark.domain.Root;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 /**
@@ -79,6 +78,34 @@ public class BookmarkTreeNode {
                 .build();
     }
 
+    public Folder toTopFolder(Root root) {
+        return Folder.builder()
+                .googleId(Integer.parseInt(id))
+                .title(title)
+                .position(index)
+                .dateAdded(dateAdded)
+                .dateGroupModified(dateGroupModified)
+                .bookmarks(new ArrayList<>())
+                .folders(new ArrayList<>())
+                .folderType(folderType)
+                .root(root)
+                .build();
+    }
+
+    public Folder toFolderWithParent(Folder folder) {
+        return Folder.builder()
+                .googleId(Integer.parseInt(id))
+                .title(title)
+                .position(index)
+                .dateAdded(dateAdded)
+                .dateGroupModified(dateGroupModified)
+                .bookmarks(new ArrayList<>())
+                .parent(folder)
+                .folders(new ArrayList<>())
+                .folderType(folderType)
+                .build();
+    }
+
     public Bookmark toBookmark(String imgUrl) {
         System.out.println("[INFO] to BOOKMARK");
         log.info("[TreeNode -> BOOKMARK] title={}, imgUrl={}", title, imgUrl);
@@ -93,6 +120,24 @@ public class BookmarkTreeNode {
                 .dateGroupModified(dateGroupModified)
                 .parentId(parentId)
                 .position(index)
+                .build();
+    }
+
+    public Bookmark toBookmark(String imgUrl, Folder folder) {
+        System.out.println("[INFO] to BOOKMARK");
+        log.info("[TreeNode -> BOOKMARK] title={}, imgUrl={}", title, imgUrl);
+        return Bookmark.builder()
+                .googleId(Long.parseLong(id))
+                .title(title)
+                .url(url)
+                .image(imgUrl)
+                .syncing(syncing)
+                .dateLastUsed(dataLastUsed)
+                .dateAdded(dateAdded)
+                .dateGroupModified(dateGroupModified)
+                .parentId(parentId)
+                .position(index)
+                .folder(folder)
                 .build();
     }
 


### PR DESCRIPTION
## 🔍 관련 이슈 
<!-- 관련된 이슈 번호를 연결하세요 (예: #23) -->
Resolve : #


## ✅ 작업 내용 요약
<!-- 어떤 작업을 했는지 한두 문장으로 요약해주세요 -->
- sync 속도 두 배 향상
- dfs 트리 순회 방식에서 bfs로 변환
- 각 폴더의 하위 북마크를 `List`로 모은 후 한번에 저장(`saveAll`)





## 💡 변경 사항 상세
<!-- 어떤 파일이 변경되었고, 주요 변경사항은 무엇인지 설명해주세요 -->
- 사용자 편의성을 위해 북마크 동기화 속도를 향상시켰습니다. 
- 기존엔 속도가 너무 느려 새로고침을 몇 번 더 하게 되었고, 이는 서버에 더 많은 부하를 발생시켜 처리속도는 더욱 느리게 하였다.
- BFS로 노드를 순회하고 saveAll로 하위 북마크를 한번에 저장하였다.


## 🧪 테스트 결과
`org.springframework.util.StopWatch`를 사용하여 시간을 측정해보니 165개 북마크 기준 2분 가량의 시간이 1분으로 단축되었습니다.

<기존 소요시간>
<img width="370" alt="image" src="https://github.com/user-attachments/assets/c6dba819-660f-4d7f-bb42-e6142452a907" />

<변경 후 소요시간>
<img width="424" alt="image" src="https://github.com/user-attachments/assets/4b693db9-3ba1-48be-9326-e3b665c15a52" />


<!--
## 🧪 테스트 결과
어떤 테스트를 했고, 결과가 어땠는지 적어주세요
- [ ] 로컬에서 테스트 완료
- [ ] 관련 테스트 코드 수정/추가
- [ ] CI 통과 확인

---


## 📸 스크린샷 (선택)
UI 작업일 경우, 변경된 화면 캡처를 첨부해주세요 
---

## 🔒 기타 참고 사항
리뷰어가 알아야 할 추가 정보가 있다면 적어주세요 (ex: 주의할 점, 트러블슈팅 등) 

---

## 🙏 리뷰어에게 바라는 점
어떤 부분을 중점적으로 봐주면 좋을지 적어주세요 (선택) 
- ex) 성능 개선이 잘 되었는지 봐주세요

-->
