### PR TITLE
og 태그가 붙은 이미지를 가져오도록 변경

### DIFF
--- a/server/src/main/java/wap/starlist/bookmark/service/BookmarkService.java
+++ b/server/src/main/java/wap/starlist/bookmark/service/BookmarkService.java
@@ -232,7 +232,7 @@ public class BookmarkService {
         try {
             //TODO: orElse로 기본 이미지 가져오기
             log.info("이미지 가져오기 - {}", url);
-            imgUrl = ImageScraper.getImageUrl(url)
+            imgUrl = ImageScraper.getImageFromOgOrImgTag(url)
                     .orElseThrow(() -> new IllegalArgumentException("[ERROR] 이미지 스크랩 실패"));
             log.info("스크랩 이미지 url: {}", imgUrl);
         } catch (IllegalArgumentException | IOException e){

--- a/server/src/main/java/wap/starlist/util/ImageScraper.java
+++ b/server/src/main/java/wap/starlist/util/ImageScraper.java
@@ -2,10 +2,12 @@ package wap.starlist.util;
 
 import java.io.IOException;
 import java.util.Optional;
+import lombok.extern.slf4j.Slf4j;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
 
+@Slf4j
 public class ImageScraper {
 
     public static Optional<String> getImageUrl(String url) throws IOException {
@@ -25,7 +27,9 @@ public class ImageScraper {
             return Optional.empty();
         }
 
-        Document doc = Jsoup.connect(url).get();
+        Document doc = Jsoup.connect(url)
+                .timeout(2000) // 2초가 지나면 타임아웃
+                .get();
 
         Element ogImage = doc.select("meta[property=og:image]").first();
         if (ogImage == null) {
@@ -42,5 +46,6 @@ public class ImageScraper {
             return Optional.of(doc.absUrl("base").isEmpty() ? content : doc.absUrl("base") + content);
         }
         return Optional.empty();
+
     }
 }

--- a/server/src/main/java/wap/starlist/util/ImageScraper.java
+++ b/server/src/main/java/wap/starlist/util/ImageScraper.java
@@ -19,4 +19,28 @@ public class ImageScraper {
         return Optional.ofNullable(thumbnail)
                 .map(img -> img.absUrl("src"));
     }
+
+    public static Optional<String> getImageFromOgOrImgTag(String url) throws IOException {
+        if (url == null || url.isEmpty()) {
+            return Optional.empty();
+        }
+
+        Document doc = Jsoup.connect(url).get();
+
+        Element ogImage = doc.select("meta[property=og:image]").first();
+        if (ogImage == null) {
+            // 없으면 img 태그에서 스크랩
+            Element thumbnail = doc.select("img").first();
+            return Optional.ofNullable(thumbnail)
+                    .map(img -> img.absUrl("src"));
+        }
+
+        // og:image 스크랩
+        String content = ogImage.attr("content");
+        if (content != null && !content.isEmpty()) {
+            // 절대경로 보장
+            return Optional.of(doc.absUrl("base").isEmpty() ? content : doc.absUrl("base") + content);
+        }
+        return Optional.empty();
+    }
 }


### PR DESCRIPTION
## ✅ 작업 내용 요약
<!-- 어떤 작업을 했는지 한두 문장으로 요약해주세요 -->
- `Jsoup`을 사용해 이미지를 스크랩할 때 og태그가 붙은 이미지를 우선적으로 가져오도록 변경
- og 이미지가 없다면 일반 이미지를 가져옴
- `Jsoup`의 html 파싱 시간을 2초로 제한




<!--
## 🧪 테스트 결과
어떤 테스트를 했고, 결과가 어땠는지 적어주세요
- [ ] 로컬에서 테스트 완료
- [ ] 관련 테스트 코드 수정/추가
- [ ] CI 통과 확인

---


## 📸 스크린샷 (선택)
UI 작업일 경우, 변경된 화면 캡처를 첨부해주세요 
---

## 🔒 기타 참고 사항
리뷰어가 알아야 할 추가 정보가 있다면 적어주세요 (ex: 주의할 점, 트러블슈팅 등) 

---

## 🙏 리뷰어에게 바라는 점
어떤 부분을 중점적으로 봐주면 좋을지 적어주세요 (선택) 
- ex) 성능 개선이 잘 되었는지 봐주세요

-->
