### PR TITLE
익스텐션 sync 성공시 refetch 자동화 로직 추가

### DIFF
--- a/client/src/components/cardlist/CardsContainer.jsx
+++ b/client/src/components/cardlist/CardsContainer.jsx
@@ -32,7 +32,7 @@ const CardsContainer = () => {
         useGetNodes(currentPosition, { enabled: !isSearching }),
         useSearchNodes(keyword, { enabled: isSearching }),
     ];
-    const { data: nodes = [], status, error } = isSearching ? searchNodesResult : getNodesResult;
+    const { data: nodes = [], status, error, refetch } = isSearching ? searchNodesResult : getNodesResult;
 
     console.log(nodes); // 디버깅용
     console.log(error); // 디버깅용
@@ -57,6 +57,17 @@ const CardsContainer = () => {
             document.removeEventListener("mousedown", handleClickOutside);
         };
     }, [handleClickOutside]);
+
+    // SYNC_SUCCESS 메시지 감지 → refetch
+    useEffect(() => {
+        function handleSyncSuccess(event) {
+            if (event.source !== window) return;
+            if (event.data.type !== "SYNC_SUCCESS") return;
+            refetch();
+        }
+        window.addEventListener("message", handleSyncSuccess);
+        return () => window.removeEventListener("message", handleSyncSuccess);
+    }, [refetch]);
 
     // 로딩중
     if (status === "loading") {

--- a/extension/public/manifest.json
+++ b/extension/public/manifest.json
@@ -1,35 +1,35 @@
 {
-  "manifest_version": 3,
-  "name": "Starlist BETA",
-  "version": "0.0.3",
-  "version_name": "0.0.3 BETA",
-  "description": "THIS EXTENSION IS FOR BETA TESTING",
-  "icons": {
-    "16":  "logo/logo16.png",
-    "32":  "logo/logo32.png",
-    "48":  "logo/logo48.png",
-    "128": "logo/logo128.png"
-  },
-  "action": {
-    "default_icon": {
-      "16":  "logo/logo16.png",
-      "32":  "logo/logo32.png",
-      "48":  "logo/logo48.png"
+    "manifest_version": 3,
+    "name": "Starlist BETA",
+    "version": "0.0.4",
+    "version_name": "0.0.4 BETA",
+    "description": "THIS EXTENSION IS FOR BETA TESTING",
+    "icons": {
+        "16": "logo/logo16.png",
+        "32": "logo/logo32.png",
+        "48": "logo/logo48.png",
+        "128": "logo/logo128.png"
     },
-    "default_popup": "./src/index.html"
-  },
-  "background": {
-    "service_worker": "./assets/js/service_worker.js"
-  },
-  "host_permissions": [
-    "https://starlist.store/*"
-  ],
-  "externally_connectable": {
-    "matches": ["https://sstarlist.netlify.app/*"]
-  },
-  "permissions": [
-    "storage",
-    "bookmarks"
-  ],
-  "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAwhHFTT/Iim2aeoyt4dhbzv1C+AGXmVKVN5NkICXpn+iI6qy/ySPntVyZ0vi1rKjwG93XFY5dsFIP7MxC+zNlK45dhQWCfAiSj0M/WZUzcGKXfmpyAmqqSnjAL+93ORwbHCk1NJJ9JCCJMTkyCxiF5QE+7XCZrLW4aj6WU2ID+jgztEmkE4QHLkAQqHcpzb+5wZp7txPg7VUBoZ4EhrG+XU0iyhGIILkOvAZZli9qSD4UkLX76fHVfQZaCP3KOTI0azeuebH79iWOd5vbmlhcF35L7yEuRs9759MmzU4g4Fi9b05XD7klK/F6ad/acDUFU5BuDvLnmaxPfnhtNyXayQIDAQAB"
+    "action": {
+        "default_icon": {
+            "16": "logo/logo16.png",
+            "32": "logo/logo32.png",
+            "48": "logo/logo48.png"
+        }
+    },
+    "background": {
+        "service_worker": "./assets/js/service_worker.js"
+    },
+    "content_scripts": [
+      {
+        "matches": ["https://sstarlist.netlify.app/*"],
+        "js": ["./assets/js/content_script.js"]
+      }
+    ],
+    "host_permissions": ["https://starlist.store/*"],
+    "externally_connectable": {
+        "matches": ["https://sstarlist.netlify.app/*"]
+    },
+    "permissions": ["storage", "bookmarks"],
+    "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAwhHFTT/Iim2aeoyt4dhbzv1C+AGXmVKVN5NkICXpn+iI6qy/ySPntVyZ0vi1rKjwG93XFY5dsFIP7MxC+zNlK45dhQWCfAiSj0M/WZUzcGKXfmpyAmqqSnjAL+93ORwbHCk1NJJ9JCCJMTkyCxiF5QE+7XCZrLW4aj6WU2ID+jgztEmkE4QHLkAQqHcpzb+5wZp7txPg7VUBoZ4EhrG+XU0iyhGIILkOvAZZli9qSD4UkLX76fHVfQZaCP3KOTI0azeuebH79iWOd5vbmlhcF35L7yEuRs9759MmzU4g4Fi9b05XD7klK/F6ad/acDUFU5BuDvLnmaxPfnhtNyXayQIDAQAB"
 }

--- a/extension/src/content_script/content_script.js
+++ b/extension/src/content_script/content_script.js
@@ -1,0 +1,11 @@
+/* global chrome */
+
+chrome.storage.onChanged.addListener((changes, areaName) => {
+        if (areaName === "local" && changes.syncSuccess) {
+            console.log('syncSuccess 감지:', changes.syncSuccess);
+            window.postMessage({
+                type: "SYNC_SUCCESS"
+            })
+        }
+    }
+)

--- a/extension/src/popup/pages/LoginPage.jsx
+++ b/extension/src/popup/pages/LoginPage.jsx
@@ -1,8 +1,18 @@
-import React from 'react';
+import React from "react";
 
 function LoginPage() {
     return (
-        <h1>test</h1>
+        <div className="flex flex-col items-center justify-center pt-4 pb-4">
+            <h2 className="text-3xl font-bold mb-8 mt-8 text-black text-center">
+                Starlist에 로그인 하시겠습니까?
+            </h2>
+            <button
+                className="mt-2 w-64 h-14 rounded-[2rem] bg-gradient-to-r from-[#836fff] to-[#1a1a1a] shadow-md text-white text-xl font-semibold transition hover:brightness-105"
+                style={{ boxShadow: "0 4px 18px 0 rgba(160, 116, 255, 0.15)" }}
+            >
+                Go
+            </button>
+        </div>
     );
 }
 

--- a/extension/src/service_worker/service_worker.js
+++ b/extension/src/service_worker/service_worker.js
@@ -1,13 +1,10 @@
 const START_PAGE_URL = import.meta.env.VITE_START_PAGE_URL;
+const MAIN_PAGE_URL = import.meta.env.VITE_MAIN_PAGE_URL;
 const API_BASE_URL = import.meta.env.VITE_API_BASE_URL;
 
 /* global chrome */
 
-
-
-// ---------- 함수 정의 영역 ---------- // 
-
-
+// ---------- 함수 정의 영역 ---------- //
 
 // 웹의 시작 페이지를 새 탭으로 생성하는 함수
 function redirectStartPage() {
@@ -17,7 +14,14 @@ function redirectStartPage() {
 // 메시지에 포함된 토큰과 동기화 여부를 storage.local 에 저장하는 함수
 async function storeAccessToken(message) {
     await chrome.storage.local.set({
-        accessToken: message.token
+        accessToken: message.token,
+    });
+}
+
+// 메인 페이지로 북마크 동기화 성공 여부를 스토리지에 기록하는 함수
+async function recordSyncSuccess() {
+    await chrome.storage.local.set({
+        syncSuccess: true,
     });
 }
 
@@ -27,11 +31,9 @@ async function getUserToken() {
         const result = await chrome.storage.local.get({ accessToken: null });
         const accessToken = result.accessToken;
 
-        if (!accessToken)
-            throw new Error("토큰이 없습니다");
+        if (!accessToken) throw new Error("토큰이 없습니다");
         return accessToken;
-    }
-    catch(error) {
+    } catch (error) {
         console.error("토큰 조회 실패:", error);
         throw error;
     }
@@ -48,8 +50,7 @@ async function fetchBookmarkTree() {
         if (!bookmarkTree?.length)
             throw new Error("기타 북마크 폴더를 찾을 수 없습니다.");
         return bookmarkTree;
-    }
-    catch(error) {
+    } catch (error) {
         console.error("북마크 조회 실패:", error);
         throw error;
     }
@@ -63,26 +64,29 @@ async function sendAllBookmarks() {
         const bookmarkPromise = fetchBookmarkTree();
 
         // 위의 비동기 작업이 모두 완료될때까지는 기다림
-        const [accessToken, bookmarkTree] = await Promise.all([tokenPromise, bookmarkPromise]);
+        const [accessToken, bookmarkTree] = await Promise.all([
+            tokenPromise,
+            bookmarkPromise,
+        ]);
 
         // 토큰과 북마크를 백엔드 API 로 전송
         const response = await fetch(`${API_BASE_URL}/bookmarks/sync`, {
             method: "POST",
             headers: {
                 "Content-Type": "application/json",
-                "Authorization": `Bearer ${accessToken}`
+                Authorization: `Bearer ${accessToken}`,
             },
-            body: JSON.stringify(bookmarkTree)
+            body: JSON.stringify(bookmarkTree),
         });
 
         if (!response.ok) {
             console.log(response);
             throw new Error(`응답 상태: ${response.status}`);
         }
-    }
-    catch (error) {
+        return true;
+    } catch (error) {
         console.error(error);
-        return;
+        return false;
     }
 }
 
@@ -123,18 +127,14 @@ async function sendAllBookmarks() {
 //     }
 // }
 
-
-
-// ---------- 이벤트 리스너 영역역 ---------- // 
-
-
+// ---------- 이벤트 리스너 영역 ---------- //
 
 // 북마크 추가, 삭제, 변경, 이동 이벤트를 정의한 배열
 const bookmarkEvents = [
-    {eventName: chrome.bookmarks.onCreated, eventType: "create"},
-    {eventName: chrome.bookmarks.onRemoved, eventType: "remove"},
-    {eventName: chrome.bookmarks.onChanged, eventType: "change"},
-    {eventName: chrome.bookmarks.onMoved, eventType: "move"}
+    { eventName: chrome.bookmarks.onCreated, eventType: "create" },
+    { eventName: chrome.bookmarks.onRemoved, eventType: "remove" },
+    { eventName: chrome.bookmarks.onChanged, eventType: "change" },
+    { eventName: chrome.bookmarks.onMoved, eventType: "move" },
 ];
 
 // 해당 이벤트들은 동일한 콜백 함수로 처리
@@ -145,11 +145,11 @@ bookmarkEvents.forEach(({ eventName, eventType }) => {
         console.log(id);
         console.log(info);
         // await syncBookmarkChanges(eventType, id, info);
-    })
+    });
 });
 
 // 확장 프로그램 프로세스 혹은 컨텐츠 스크립트에서 메시지가 전송될때 실행됨
-chrome.runtime.onMessage.addListener(async message => {
+chrome.runtime.onMessage.addListener(async (message) => {
     switch (message.type) {
         case "LOGIN_BUTTON_CLICKED":
             console.log("로그인 버튼 클릭 감지");
@@ -162,7 +162,7 @@ chrome.runtime.onMessage.addListener(async message => {
 });
 
 // 다른 확장 프로그램이나 웹 페이지에서 메시지가 전송될 때 실행됨
-chrome.runtime.onMessageExternal.addListener(async message => {
+chrome.runtime.onMessageExternal.addListener(async (message) => {
     switch (message.type) {
         case "LOGIN_SUCCESS":
             console.log("로그인 감지");
@@ -171,7 +171,13 @@ chrome.runtime.onMessageExternal.addListener(async message => {
 
         case "NEW_USER_DETECTION": {
             console.log("신규 유저 감지");
-            await sendAllBookmarks();
+            const syncSuccess = await sendAllBookmarks();
+            if (syncSuccess) {
+                console.log("sendAllBookmarks 성공");
+                await recordSyncSuccess();
+            } 
+            else
+                console.error("sendAllBookmarks 실패");
             break;
         }
 


### PR DESCRIPTION
## ✅ 작업 내용 요약
<!-- 어떤 작업을 했는지 한두 문장으로 요약해주세요 -->
- `CardsContainer` 에서 컨텐츠 스크립트에서 전송한 메시지를 수신하기 위해 이벤트 리스너를 등록, 이후 해당 메시지를 성공적으로 수신하면 refetch 를 시도하게끔 수정
- `service_worker` 에서 `sendAllBookmarks()` 성공시 로컬 스토리지에 `syncSuccess` flag 를 true 로 설정하고 이를 컨텐츠 스크립트가 변화를 감지하여 메인 페이지에 메시지를 송신하도록 변경
- `content_script` 는 `window.postMessage` 를 사용하여 메인 페이지에 메시지를 송신
- `manifest.json` 에 컨텐츠 스크립트를 주입하기 위한 권한을 추가
- 익스텐션 UI 를 현재는 삭제함