### PR TITLE
카드 리스트, 헤더 CSS 오류 및 북마크/폴더 수정 API 오타 수정

### DIFF
--- a/client/src/components/cardlist/CardList.jsx
+++ b/client/src/components/cardlist/CardList.jsx
@@ -5,7 +5,7 @@ import CardsContainer from "./CardsContainer";
 
 const CardList = () => {
     return (
-        <div className="mx-auto flex w-full flex-col px-10">
+        <div className="my-4 flex w-full flex-col gap-y-10 px-10">
             <Toolbar />
             <CardsContainer />
         </div>

--- a/client/src/components/cardlist/CardsContainer.jsx
+++ b/client/src/components/cardlist/CardsContainer.jsx
@@ -98,7 +98,7 @@ const CardsContainer = () => {
 
     // 데이터 있을때
     return (
-        <div ref={containerRef} className="mt-[83px] min-h-[calc(100vh-83px)] grid grid-cols-1 gap-6 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4">
+        <div ref={containerRef} className="mb-48 grid grid-cols-1 gap-6 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4">
             {nodes.map((node) =>
                 node.url === null ? (
                     <FolderCard key={node.index} info={node} />

--- a/client/src/components/header/Header.jsx
+++ b/client/src/components/header/Header.jsx
@@ -12,18 +12,15 @@ const Header = () => {
     };
 
     const handleProfileClick = () => {
-        setShowLogout(prev => !prev);
+        setShowLogout((prev) => !prev);
     };
 
     return (
-        <header className="border-gray-300-[2px] border-b h-[128px] relative">
-            <div className="mb-9 mt-2 mx-4 flex items-center justify-between">
+        <header className="border-gray-300-[2px] relative border-b">
+            <div className="mx-4 mb-16 mt-2 flex items-center justify-between">
                 <LogoIcon onClick={logoClick} />
                 <div className="flex gap-x-4">
-                    <ProfileIcon
-                        onClick={handleProfileClick}
-                        className="h-[30px] w-[30px] cursor-pointer"
-                    />
+                    <ProfileIcon onClick={handleProfileClick} className="h-[30px] w-[30px] cursor-pointer" />
                     <Link to="/setting">
                         <SettingIcon className="h-[30px] w-[30px]" />
                     </Link>

--- a/client/src/functions/utils/editBookmark.js
+++ b/client/src/functions/utils/editBookmark.js
@@ -13,7 +13,7 @@ async function editBookmark(bookmarkId, payload) {
         body: JSON.stringify(payload),
     };
 
-    const response = await fetch(`${API_BASE_URL}/${bookmarkId}/edit`, options);
+    const response = await fetch(`${API_BASE_URL}/bookmarks/${bookmarkId}/edit`, options);
 
     // 200 OK 가 아닐 경우
     if (!response.ok) {

--- a/client/src/functions/utils/editFolder.js
+++ b/client/src/functions/utils/editFolder.js
@@ -14,7 +14,7 @@ async function editFolder(folderId, payload) {
         body: JSON.stringify(payload),
     };
 
-    const response = await fetch(`${API_BASE_URL}/${folderId}/edit`, options);
+    const response = await fetch(`${API_BASE_URL}/folders/${folderId}/edit`, options);
 
     // 200 OK 가 아닐 경우
     if (!response.ok) {


### PR DESCRIPTION
## ✅ 작업 내용 요약
- 북마크/폴더 수정 API 에서 URL 을 원래 `folders/{id}/edit` 과 `bookmarks/{id}/edit` 와 같은 형식으로 보내야 했으나 folders, bookmarks 를 누락해서 작성하여 오류가 발생하였습니다. 이를 수정하였습니다.
- 카드리스트에서 height 값을 `min-h-[calc(100vh-83px)]` 와 같은 속성으로 부여하고 있었는데, 이를 삭제하고 padding, margin, gap 값을 적절하게 조절하여 레이아웃을 처리하도록 변경하였습니다.


## 📸 스크린샷
- 북마크/폴더 수정 API URL 오타 발생
![image](https://github.com/user-attachments/assets/2e997a95-54af-4b6f-b109-0f51ea2840e3)

- 카드리스트 높이 CSS 오류 발생
![image](https://github.com/user-attachments/assets/904b195a-4ed4-4f1e-aab4-49d7148d7b49)


