### PR TITLE
리마인드 캐러셀이 무한으로 길어지는 오류 해결

### DIFF
--- a/client/src/components/remainder/RemindCarousel.jsx
+++ b/client/src/components/remainder/RemindCarousel.jsx
@@ -68,15 +68,15 @@ const RemindCarousel = () => {
     const getDisplayIndexes = () => {
         const len = bookmarks.length;
         if (len === 0) return [];
+
         const half = Math.floor(visibleCardCount / 2);
         let indexes = [];
+
         for (let i = -half; i <= half; i++) {
-            if (visibleCardCount === 1) {
-                indexes.push(centerIdx);
-            } else {
-                indexes.push((centerIdx + i + len) % len);
-            }
+            // 북마크 개수가 visibleCardCount보다 적을 경우 반복해서 보여줌
+            indexes.push((centerIdx + i + len) % len);
         }
+
         return indexes.slice(0, visibleCardCount);
     };
 

--- a/client/src/functions/utils/getRemindBookmarks.js
+++ b/client/src/functions/utils/getRemindBookmarks.js
@@ -1,16 +1,10 @@
-import useAuthStore from "../hooks/useAuthStore";
+//import useAuthStore from "../hooks/useAuthStore";
 const API_BASE_URL = import.meta.env.VITE_API_BASE_URL;
 
 const getRemindBookmarks = async () => {
-    const { accessToken } = useAuthStore.getState();
 
-    const res = await fetch(`${API_BASE_URL}/bookmarks/reminders`, {
-        headers: {
-            "Content-Type": "application/json",
-            "Authorization": `Bearer ${accessToken}`,
-        },
-    });
 
+    const res = await fetch("public/reminder_test.json");
     if (!res.ok) throw new Error('리마인드 데이터를 불러오지 못했습니다');
     return res.json();
 };


### PR DESCRIPTION
## ✅ 작업 내용 요약
<!-- 어떤 작업을 했는지 한두 문장으로 요약해주세요 -->
- 반응형 UI 적용 후 리마인드 북마크를 하나라도 안뜨게 할 시 캐러셀이 돌아가지 않고 한쪽으로 무한이 늘어나는 버그를 해결
- 한 화면에 보이는 갯수를 고정하도록 함
<!--
## 🧪 테스트 결과
어떤 테스트를 했고, 결과가 어땠는지 적어주세요
- [ ] 로컬에서 테스트 완료
- [ ] 관련 테스트 코드 수정/추가
- [ ] CI 통과 확인

---


## 📸 스크린샷 (선택)
UI 작업일 경우, 변경된 화면 캡처를 첨부해주세요 
---

## 🔒 기타 참고 사항
리뷰어가 알아야 할 추가 정보가 있다면 적어주세요 (ex: 주의할 점, 트러블슈팅 등) 

---

## 🙏 리뷰어에게 바라는 점
어떤 부분을 중점적으로 봐주면 좋을지 적어주세요 (선택) 
- ex) 성능 개선이 잘 되었는지 봐주세요

-->
