### PR TITLE
검색창 버그 수정, BreadCrumb 폴더 이동 수정, fetchFolderTree 수정

### DIFF
--- a/client/src/components/cardlist/BreadCrumb.jsx
+++ b/client/src/components/cardlist/BreadCrumb.jsx
@@ -6,10 +6,10 @@ import { ArrowForwardIcon } from "../../assets";
 const BreadCrumb = () => {
     const history = useFolderHistoryStore((s) => s.history);
     const currentPosition = history[history.length - 1].id;
-    const move = useFolderHistoryStore((s) => s.move);
+    const goBack = useFolderHistoryStore((s) => s.goBack);
 
     const onClick = (id) => {
-        move(id);
+        goBack(id);
     };
 
     return (

--- a/client/src/components/cardlist/FolderCard.jsx
+++ b/client/src/components/cardlist/FolderCard.jsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import useFolderHistoryStore from "../../functions/hooks/useFolderHistoryStore";
+import useMoveToFolder from "../../functions/hooks/useMoveToFolder";
 import useSelectedCardsStore from "../../functions/hooks/useSelectedCardsStore";
 
 import { FolderCardSvg } from "../../assets/";
@@ -7,8 +7,8 @@ import { EditButton } from "../../assets/";
 import FolderEditModal from "./FolderEditModal";
 
 const FolderCard = ({ info }) => {
-    // 폴더 카드 클릭시 현재 history 를 변경
-    const push = useFolderHistoryStore((s) => s.push);
+    // 폴더 카드 클릭시 history 변경
+    const moveToFolder = useMoveToFolder();
 
     // Ctrl + 좌클릭을 이용하여 해당 카드를 선택 가능
     const isSelected = useSelectedCardsStore((s) =>
@@ -25,7 +25,7 @@ const FolderCard = ({ info }) => {
             e.preventDefault();
             toggle(info.id, "folder");
         } else {
-            push({ id: info.id, title: info.title });
+            moveToFolder(info.id, info.title);
         }
     };
 

--- a/client/src/components/cardlist/MoveButton.jsx
+++ b/client/src/components/cardlist/MoveButton.jsx
@@ -21,7 +21,7 @@ const MoveButton = ({ targets = [], onClose, buttonText = "", className = "" }) 
     const dropdownRef = useRef(null);
 
     // 폴더 트리 데이터와 로딩 상태 조회
-    const { data: folderTree = [], status, error } = useFolderTree();
+    const { data: folderTree = {}, status, error } = useFolderTree();
 
     // 이동에 대한 쿼리를 담당하는 객체
     const { moveNodesMutaion } = useNodeActions();
@@ -113,7 +113,7 @@ const MoveButton = ({ targets = [], onClose, buttonText = "", className = "" }) 
                     className={`absolute left-0 z-50 w-full overflow-y-auto rounded bg-white shadow-lg ${shouldFlipDropDown ? "bottom-full mb-2" : "top-full mt-2"} `}
                 >
                     <DropDownFolderTree
-                        folderTree={folderTree}
+                        folderTree={folderTree.children}
                         currentlyOpenFolders={currentlyOpenFolders}
                         setCurrentlyOpenFolders={setCurrentlyOpenFolders}
                         onSelect={handleMove}

--- a/client/src/components/cardlist/SearchBar.jsx
+++ b/client/src/components/cardlist/SearchBar.jsx
@@ -4,7 +4,7 @@ import { Search } from "../../assets";
 
 const SearchBar = () => {
     const setKeyword = useSearchStore((s) => s.setKeyword);
-    const clear = useSearchStore((s) => s.clear);
+    const finishSearch = useSearchStore((s) => s.finishSearch);
 
     const [input, setInput] = useState("");
 
@@ -14,23 +14,24 @@ const SearchBar = () => {
         setKeyword(input.trim()); // 공백 제거 후 전달
     };
 
-    // input 포커스 잃을 때(clear)
-    const handleBlur = () => {
-        clear();
-        setInput(""); // 입력창도 비워주면 UX적으로 좋음
+    // input이 비워질 때만 검색 종료
+    const handleInputChange = (e) => {
+        const currentValue = e.target.value;
+        setInput(currentValue);
+        if (currentValue.trim() === "") finishSearch();
+    };
+
+    // X 버튼 클릭 시
+    const handleClearClick = () => {
+        setInput("");
+        finishSearch();
     };
 
     return (
         <form
             name="search"
             onSubmit={handleSubmit}
-            className={`
-                    relative
-                    w-full
-                    sm:w-[280px]
-                    md:w-[358px]
-                    lg:w-[358px]
-                `}
+            className={`relative w-full sm:w-[280px] md:w-[358px] lg:w-[358px]`}
         >
             <input
                 type="text"
@@ -38,34 +39,20 @@ const SearchBar = () => {
                 placeholder="검색"
                 required
                 value={input}
-                onChange={e => setInput(e.target.value)}
-                onBlur={handleBlur}
-                className={`
-                        w-full
-                        h-8 sm:h-9
-                        md:h-10 lg:h-[43px]
-                        rounded-full
-                        border-2 border-black
-                        px-3 sm:px-4
-                        md:px-5 lg:px-6
-                        text-xs sm:text-sm
-                        md:text-base lg:text-base
-                        placeholder-gray-500
-                        focus:outline-none focus:bg-gray-50
-                    `}
+                onChange={handleInputChange}
+                className={`h-8 w-full rounded-full border-2 border-black px-3 text-xs placeholder-gray-500 focus:bg-gray-50 focus:outline-none sm:h-9 sm:px-4 sm:text-sm md:h-10 md:px-5 md:text-base lg:h-[43px] lg:px-6 lg:text-base`}
             />
+            {input && (
+                <button
+                    type="button"
+                    onClick={handleClearClick}
+                    className="absolute right-10 top-1/2 -translate-y-1/2 text-gray-400 hover:text-main-500"
+                >
+                    ×
+                </button>
+            )}
             <Search
-                className={`
-                        absolute
-                        right-2 sm:right-3
-                        md:right-4 lg:right-4
-                        top-1/2 -translate-y-1/2
-                        w-4 h-4
-                        sm:w-5 sm:h-5
-                        md:w-6 md:h-6
-                        lg:w-6 lg:h-6
-                        text-gray-500
-                    `}
+                className={`absolute right-2 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-500 sm:right-3 sm:h-5 sm:w-5 md:right-4 md:h-6 md:w-6 lg:right-4 lg:h-6 lg:w-6`}
             />
         </form>
     );

--- a/client/src/components/modal/AddBookmarkModal.jsx
+++ b/client/src/components/modal/AddBookmarkModal.jsx
@@ -6,7 +6,7 @@ import { PlusBookmark } from "../../assets";
 // AddBookmarkModal 컴포넌트: 새 북마크 추가용 모달창
 const AddBookmarkModal = ({ onClose }) => {
     // 폴더 트리 데이터와 로딩 상태 조회
-    const { data: tree = [], isLoading } = useFolderTree();
+    const { data: folderTree = {}, isLoading } = useFolderTree();
     // 북마크 추가 뮤테이션 함수
     const { addBookmarkMutation } = useNodeActions();
 
@@ -31,7 +31,7 @@ const AddBookmarkModal = ({ onClose }) => {
                 { name: "title", label: "이름", placeholder: "북마크 이름" },
                 { name: "url", label: "URL", placeholder: "https://..." },
             ]}
-            tree={tree} // 폴더 트리 옵션
+            tree={folderTree.children} // 폴더 트리 옵션
             isLoading={isLoading} // 로딩 상태
             buttonText="추가하기" // 버튼 텍스트
             onSubmit={handleBookmarkSubmit} // 제출 콜백

--- a/client/src/components/modal/AddFolderModal.jsx
+++ b/client/src/components/modal/AddFolderModal.jsx
@@ -6,7 +6,7 @@ import { PlusFolder } from "../../assets";
 // AddFolderModal 컴포넌트: 새 폴더 추가용 모달창
 const AddFolderModal = ({ onClose }) => {
     // 폴더 트리 데이터와 로딩 상태 조회
-    const { data: tree = [], isLoading } = useFolderTree();
+    const { data: folderTree = {}, isLoading } = useFolderTree();
     // 폴더 추가 뮤테이션 함수
     const { addFolderMutation } = useNodeActions();
 
@@ -27,7 +27,7 @@ const AddFolderModal = ({ onClose }) => {
             title="새 폴더 추가" // 모달 제목
             icon={PlusFolder} // 모달 아이콘
             fields={[{ name: "title", label: "이름", placeholder: "폴더 이름" }]} // 입력 필드 설정
-            tree={tree} // 폴더 트리 옵션
+            tree={folderTree.children} // 폴더 트리 옵션
             isLoading={isLoading} // 로딩 상태
             buttonText="추가하기" // 버튼 텍스트
             onSubmit={handleFolderSubmit} // 제출 콜백

--- a/client/src/functions/hooks/useFolderHistoryStore.js
+++ b/client/src/functions/hooks/useFolderHistoryStore.js
@@ -3,20 +3,28 @@ import { create } from "zustand";
 const useFolderHistoryStore = create((set) => ({
     history: [{ id: 0, title: "나의 북마크" }],
 
-    push: (node) => set((state) => ({
-        history: [...state.history, node]
-    })),
+    push: (node) =>
+        set((state) => ({
+            history: [...state.history, node],
+        })),
 
-    pop: () => set((state) => ({
-        history: state.history.slice(0, -1)
-    })),
+    pop: () =>
+        set((state) => ({
+            history: state.history.slice(0, -1),
+        })),
 
-    move: (id) => set((state) => {
-        const targetIdx = state.history.findIndex((node) => node.id === id);
-        return {
-            history: state.history.slice(0, targetIdx + 1)
-        };
-    })
+    goBack: (id) =>
+        set((state) => {
+            const targetIdx = state.history.findIndex((node) => node.id === id);
+            return {
+                history: state.history.slice(0, targetIdx + 1),
+            };
+        }),
+
+    setHistory: (newHistory) =>
+        set(() => ({
+            history: newHistory,
+        })),
 }));
 
 export default useFolderHistoryStore;

--- a/client/src/functions/hooks/useFolderTree.js
+++ b/client/src/functions/hooks/useFolderTree.js
@@ -1,48 +1,45 @@
+import { useQuery, keepPreviousData } from "@tanstack/react-query";
 import useAuthStore from "../hooks/useAuthStore";
-import { useQuery } from "@tanstack/react-query";
-
+import ApiError from "../utils/ApiError";
 const API_BASE_URL = import.meta.env.VITE_API_BASE_URL;
+const FOLDER_URL = import.meta.env.VITE_FOLDER_URL;
 
-const fetchFolderTree = async () => {
-    const token = useAuthStore.getState().accessToken?.trim();
-    if (!token) {
-        console.log("[fetchFolderTree] 토큰 없음, 빈 배열 반환");
-        return [];
-    }
-
-    const res = await fetch(`${API_BASE_URL}/folders/tree`, {
+async function fetchFolderTree() {
+    const { accessToken } = useAuthStore.getState();
+    const options = {
+        method: "GET",
         headers: {
-            Authorization: `Bearer ${token}`,
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${accessToken}`,
         },
-    });
-    console.log("[fetchFolderTree] fetch status:", res.status);
-    if (!res.ok) {
-        const errorBody = await res.text();
-        console.log("[fetchFolderTree] fetch 실패, errorBody:", errorBody);
-        return [];
-    }
-    const data = await res.json();
-    console.log("[fetchFolderTree] data 응답:", data);
-    const ret = Array.isArray(data)
-        ? data
-        : Array.isArray(data.children)
-            ? data.children
-            : [];
-    console.log("[fetchFolderTree] 최종 반환:", ret);
-    return ret;
-};
+    };
 
-const useFolderTree = () => {
-    const token = useAuthStore(state => state.accessToken);
+    const response = await fetch(`${FOLDER_URL}`, options);
+    // 200 OK 가 아닐 경우
+    if (!response.ok) {
+        const errorBody = await response.json();
+        console.log(errorBody);
+        throw new ApiError(errorBody.code, errorBody.message, response);
+    }
+    return await response.json();
+}
+
+function useFolderTree() {
     return useQuery({
-        queryKey: ["folderTree", token], // 토큰이 바뀔 때 refetch
-        queryFn: fetchFolderTree,
-        staleTime: 600_000,
-        cacheTime: 600_000,
-        retry: 1,
-        enabled: !!token && token.length > 0,
-        keepPreviousData: true, // 이전 데이터를 잠깐 유지
+        queryKey: ["folderTree"],
+        queryFn: () => fetchFolderTree(),
+
+        staleTime: 1000 * 60 * 10,
+        gcTime: 1000 * 60 * 20,
+
+        // 상황별 refetch 여부를 나타내는 옵션
+        refetchOnWindowFocus: false,
+        refetchOnMount: false,
+        refetchOnReconnect: true,
+        retry: false,
+
+        placeholderData: keepPreviousData,
     });
-};
+}
 
 export default useFolderTree;

--- a/client/src/functions/hooks/useFolderTree.js
+++ b/client/src/functions/hooks/useFolderTree.js
@@ -2,7 +2,6 @@ import { useQuery, keepPreviousData } from "@tanstack/react-query";
 import useAuthStore from "../hooks/useAuthStore";
 import ApiError from "../utils/ApiError";
 const API_BASE_URL = import.meta.env.VITE_API_BASE_URL;
-const FOLDER_URL = import.meta.env.VITE_FOLDER_URL;
 
 async function fetchFolderTree() {
     const { accessToken } = useAuthStore.getState();
@@ -14,7 +13,7 @@ async function fetchFolderTree() {
         },
     };
 
-    const response = await fetch(`${FOLDER_URL}`, options);
+    const response = await fetch(`${API_BASE_URL}/folders/tree`, options);
     // 200 OK 가 아닐 경우
     if (!response.ok) {
         const errorBody = await response.json();

--- a/client/src/functions/hooks/useMoveToFolder.js
+++ b/client/src/functions/hooks/useMoveToFolder.js
@@ -1,0 +1,30 @@
+import useFolderHistoryStore from "./useFolderHistoryStore";
+import useSearchStore from "./useSearchStore";
+import useFolderTree from "./useFolderTree";
+import findFolderPath from "../utils/findFolderPath";
+
+function useMoveToFolder() {
+    // 검색 여부에 따라 폴더 이동 로직을 다르게 처리
+    const isSearching = useSearchStore((s) => s.isSearching);
+    const finishSearch = useSearchStore((s) => s.finishSearch);
+
+    // 검색 O : setHistory / 검색 X : push
+    const push = useFolderHistoryStore((s) => s.push);
+    const setHistory = useFolderHistoryStore((s) => s.setHistory);
+
+    const { data: folderTree = {} } = useFolderTree();
+
+    return (id, title) => {
+        if (isSearching) {
+            // 검색중이라면 해당 폴더의 경로를 히스토리로 지정
+            const path = findFolderPath(folderTree, id);
+            setHistory(path);
+            finishSearch();
+        } else {
+            // 아니라면 단순히 현재 히스토리 스택에 추가
+            push({ id, title });
+        }
+    };
+};
+
+export default useMoveToFolder;

--- a/client/src/functions/hooks/useSearchStore.js
+++ b/client/src/functions/hooks/useSearchStore.js
@@ -6,7 +6,7 @@ const useSearchStore = create((set) => ({
     keyword: "",
     isSearching: false,
     setKeyword: (newKeyword) => set({ keyword: newKeyword, isSearching: true }),
-    clear: () => set({ keyword: "", isSearching: false }),
+    finishSearch: () => set({ keyword: "", isSearching: false }),
 }));
 
 export default useSearchStore;

--- a/client/src/functions/utils/fetchNodesByPath.js
+++ b/client/src/functions/utils/fetchNodesByPath.js
@@ -2,13 +2,12 @@ import useAuthStore from "../hooks/useAuthStore";
 import ApiError from "./ApiError";
 
 const API_BASE_URL = import.meta.env.VITE_API_BASE_URL;
-const MOCKY_URL = import.meta.env.VITE_MOCKY_URL;
 
 // path 에 따른 노드 리스트를 백엔드 API 를 통해 가져오는 함수
 async function fetchNodesByPath(path) {
     const { accessToken } = useAuthStore.getState();
 
-    const response = await fetch(`${MOCKY_URL}${path}`, {
+    const response = await fetch(`${API_BASE_URL}${path}`, {
         method: "GET",
         headers: {
             "Content-Type": "application/json",

--- a/client/src/functions/utils/fetchNodesByPath.js
+++ b/client/src/functions/utils/fetchNodesByPath.js
@@ -2,12 +2,13 @@ import useAuthStore from "../hooks/useAuthStore";
 import ApiError from "./ApiError";
 
 const API_BASE_URL = import.meta.env.VITE_API_BASE_URL;
+const MOCKY_URL = import.meta.env.VITE_MOCKY_URL;
 
 // path 에 따른 노드 리스트를 백엔드 API 를 통해 가져오는 함수
 async function fetchNodesByPath(path) {
     const { accessToken } = useAuthStore.getState();
 
-    const response = await fetch(`${API_BASE_URL}${path}`, {
+    const response = await fetch(`${MOCKY_URL}${path}`, {
         method: "GET",
         headers: {
             "Content-Type": "application/json",

--- a/client/src/functions/utils/findFolderPath.js
+++ b/client/src/functions/utils/findFolderPath.js
@@ -1,0 +1,37 @@
+/**
+ *
+ * @param {object} folderTree (루트 폴더의 자식 노드부터 시작한다고 가정)
+ * @param {number} targetFolderId
+ * @param {list[object]} currentPath
+ * @returns {list[object] || null} result
+ */
+
+// 재귀적으로 현재 폴더 트리에서 타깃 폴더까지의 경로를 찾는 함수
+function findFolderPath(folderTree, targetFolderId, currentPath = []) {
+    // 루트 폴더는 추가하고 시작
+    if (currentPath.length === 0)
+        findFolderPath(folderTree, targetFolderId, [...currentPath, { id: 0, title: "나의 북마크" }]);
+
+    // 현재까지 누적된 폴더 경로에 현재 폴더를 추가
+    const updatedPath = [...currentPath, { id: folderTree.id, title: folderTree.title }];
+
+    // Base case 1. empty tree 라면
+    if (!folderTree) return null;
+
+    // Base case 2. 타깃 id 를 찾았다면
+    if (folderTree.id === targetFolderId) return updatedPath;
+
+    // Base case 3. 현재 트리의 자식이 없다면
+    if (!folderTree.children) return null;
+
+    // 현재 자식 노드들에 대해서 재귀적으로 탐색하고 하나라도 성공하는 케이스가 있다면 반환
+    for (const child of folderTree.children) {
+        const result = findFolderPath(child, targetFolderId, updatedPath);
+        if (result) return result;
+    }
+
+    // 모든 경우의 수를 탐색했으나 없다면
+    return null;
+}
+
+export default findFolderPath;


### PR DESCRIPTION
## ✅ 작업 내용 요약
<!-- 어떤 작업을 했는지 한두 문장으로 요약해주세요 -->
- 검색을 통해 가져온 북마크, 폴더 리스트를 실제로 사용할 수 없었던 버그를 수정하였습니다.
- 검색을 통해 가져온 폴더의 경우, 폴더 카드 클릭시 해당 폴더 경로에 맞게끔 `BreadCrumb` 를 최신화하여야 했는데 이를 구현하기 위한 로직을 추가하였습니다.
- 현재 `useFolderTree` 에서는 루트 폴더를 포함한 object 가 아닌 chilren 배열을 가져오도록 하고 있었으나, `findFolderPath` 에서 구현 복잡도를 줄이기 위해서 그대로 object 를 반환하되 기존의 컴포넌트의 기능을 해치지 않게끔 수정하였습니다.