### PR TITLE
findFolderPath 로직 오류 및 카드리스트 렌더링 오류 수정

### DIFF
--- a/client/src/components/cardlist/CardsContainer.jsx
+++ b/client/src/components/cardlist/CardsContainer.jsx
@@ -101,9 +101,9 @@ const CardsContainer = () => {
         <div ref={containerRef} className="mb-48 grid grid-cols-1 gap-6 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4">
             {nodes.map((node) =>
                 node.url === null ? (
-                    <FolderCard key={node.index} info={node} />
+                    <FolderCard key={`folder-${node.id}`} info={node} />
                 ) : (
-                    <BookmarkCard key={node.index} info={node} />
+                    <BookmarkCard key={`bookmark-${node.id}`} info={node} />
                 ),
             )}
         </div>

--- a/client/src/functions/utils/findFolderPath.js
+++ b/client/src/functions/utils/findFolderPath.js
@@ -8,9 +8,11 @@
 
 // 재귀적으로 현재 폴더 트리에서 타깃 폴더까지의 경로를 찾는 함수
 function findFolderPath(folderTree, targetFolderId, currentPath = []) {
-    // 루트 폴더는 추가하고 시작
-    if (currentPath.length === 0)
-        findFolderPath(folderTree, targetFolderId, [...currentPath, { id: 0, title: "나의 북마크" }]);
+    // 루트 폴더는 다음과 같은 값을 사용
+    if (currentPath.length === 0) {
+        folderTree.id = 0;
+        folderTree.title = "나의 북마크";
+    }
 
     // 현재까지 누적된 폴더 경로에 현재 폴더를 추가
     const updatedPath = [...currentPath, { id: folderTree.id, title: folderTree.title }];


### PR DESCRIPTION
## ✅ 작업 내용 요약
<!-- 어떤 작업을 했는지 한두 문장으로 요약해주세요 -->
- 현재 카드리스트에서 사용하는 `map` 함수는 key 를 index 를 사용하고 있는데, 이를 백엔드 DB 의 북마크, 폴더 테이블의 기본키인 id 를 사용하되, 북마크와 폴더 간의 id 중복을 피하기 위해서 prefix string (ex. 폴더: `folder`, 북마크: `bookmark`) + id 조합을 사용하여 key 고유성을 보장하도록 변경하였습니다.
- `findFolderPath` 에서 `currentPath` 가 빈 배열이라면  "루트 폴더를 추가하고 시작하자!" 라는 의도로 코드를 작성하였으나, Recursion 특성을 잘못 생각하여 제대로 `currentPath` 를 구할 수 없었습니다. 이를 의도에 맞게 정상적으로 수정하였습니다.


## 📸 스크린샷
- key 중복으로 인한 렌더링 오류 발생 화면
![image](https://github.com/user-attachments/assets/9e348a6e-d245-4c3b-87be-af4ee82af106)


